### PR TITLE
feat(settings): rebuild settings dialog for accessibility reliability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "paramiko>=3.0",
     "keyring>=25.0",
-    "wxPython>=4.2",
+    "wxPython==4.2.4",
     "prismatoid",
 ]
 

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -1163,20 +1163,31 @@ class MainFrame(wx.Frame):
         pass
 
     def _on_settings(self, event: wx.CommandEvent) -> None:
-        dlg = SettingsDialog(self, self._settings)
-        if dlg.ShowModal() == wx.ID_OK:
-            self._settings = dlg.get_settings()
-            update_last_local_folder(self._settings, self._local_cwd)
-            save_settings(self._settings)
-            self._populate_file_list(
-                self.remote_file_list,
-                self._get_visible_files(self._remote_files, self._remote_filter_text),
+        dlg = None
+        try:
+            dlg = SettingsDialog(self, self._settings)
+            if dlg.ShowModal() == wx.ID_OK:
+                self._settings = dlg.get_settings()
+                update_last_local_folder(self._settings, self._local_cwd)
+                save_settings(self._settings)
+                self._populate_file_list(
+                    self.remote_file_list,
+                    self._get_visible_files(self._remote_files, self._remote_filter_text),
+                )
+                self._populate_file_list(
+                    self.local_file_list,
+                    self._get_visible_files(self._local_files, self._local_filter_text),
+                )
+        except Exception as e:
+            logger.exception("Failed to open settings dialog")
+            wx.MessageBox(
+                f"Could not open Settings dialog:\n{e}",
+                "Settings Error",
+                wx.OK | wx.ICON_ERROR,
             )
-            self._populate_file_list(
-                self.local_file_list,
-                self._get_visible_files(self._local_files, self._local_filter_text),
-            )
-        dlg.Destroy()
+        finally:
+            if dlg:
+                dlg.Destroy()
 
     def _on_about(self, event: wx.CommandEvent) -> None:
         info = wx.adv.AboutDialogInfo()

--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -73,7 +73,8 @@ class SettingsDialog(wx.Dialog):
 
         control.SetName(control_name)
         row.Add(row_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        row.Add(control, 1, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+        # Don't combine alignment flags with EXPAND; wx asserts in debug builds.
+        row.Add(control, 1, wx.EXPAND)
 
         parent_sizer.Add(row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
         return control

--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -15,196 +15,346 @@ class SettingsDialog(wx.Dialog):
             parent,
             title="Settings",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
-            size=(450, 400),
+            size=(560, 460),
         )
         self._settings = settings
+        self._spin_controls: list[wx.SpinCtrl] = []
+
         self._build_ui()
         self._populate()
         self.SetName("Settings Dialog")
 
+        self.Bind(wx.EVT_SHOW, self._on_show)
+        self.Bind(wx.EVT_WINDOW_CREATE, self._on_window_create)
+
     def _build_ui(self) -> None:
-        sizer = wx.BoxSizer(wx.VERTICAL)
+        root = wx.BoxSizer(wx.VERTICAL)
+
         self.notebook = wx.Notebook(self)
-        self.notebook.SetName("Settings Categories")
+        self.notebook.SetName("Settings categories")
 
         self._build_transfer_tab()
         self._build_display_tab()
         self._build_connection_tab()
         self._build_speech_tab()
 
-        sizer.Add(self.notebook, 1, wx.EXPAND | wx.ALL, 8)
-        btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
-        sizer.Add(btn_sizer, 0, wx.ALL | wx.EXPAND, 8)
-        self.SetSizer(sizer)
+        root.Add(self.notebook, 1, wx.EXPAND | wx.ALL, 8)
 
-    def _add_field(self, parent, grid, label_text, ctrl, name=None):
-        lbl = wx.StaticText(parent, label=label_text)
-        grid.Add(lbl, 0, wx.ALIGN_CENTER_VERTICAL)
-        if name:
-            ctrl.SetName(name)
-        grid.Add(ctrl, 1, wx.EXPAND)
-        return ctrl
+        buttons = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        root.Add(buttons, 0, wx.ALL | wx.EXPAND, 8)
+
+        self.SetSizer(root)
+
+    def _new_tab_panel(self) -> tuple[wx.Panel, wx.BoxSizer]:
+        panel = wx.Panel(self.notebook)
+        panel_sizer = wx.BoxSizer(wx.VERTICAL)
+        panel.SetSizer(panel_sizer)
+        return panel, panel_sizer
+
+    def _add_labeled_row(
+        self,
+        panel: wx.Panel,
+        parent_sizer: wx.BoxSizer,
+        *,
+        label: str,
+        control: wx.Control,
+        control_name: str,
+    ) -> wx.Control:
+        row = wx.BoxSizer(wx.HORIZONTAL)
+
+        row_label = wx.StaticText(panel, label=label)
+        row_label.SetName(control_name)
+        row_label.SetMinSize((240, -1))
+        row_label.Wrap(-1)
+
+        if hasattr(row_label, "SetLabelFor"):
+            row_label.SetLabelFor(control)
+
+        control.SetName(control_name)
+        row.Add(row_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+        row.Add(control, 1, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+
+        parent_sizer.Add(row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+        return control
+
+    def _add_checkbox_row(
+        self,
+        parent_sizer: wx.BoxSizer,
+        checkbox: wx.CheckBox,
+        *,
+        name: str,
+    ) -> wx.CheckBox:
+        checkbox.SetName(name)
+        parent_sizer.Add(checkbox, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+        return checkbox
+
+    def _register_spin(self, spin: wx.SpinCtrl, name: str) -> wx.SpinCtrl:
+        self._spin_controls.append(spin)
+        self._set_spin_context(spin, name)
+        return spin
+
+    def _set_spin_context(self, spin: wx.SpinCtrl, name: str) -> None:
+        spin.SetName(name)
+        spin.SetToolTip(name)
+
+        text_child = self._find_text_child(spin)
+        if text_child is not None and hasattr(text_child, "SetName"):
+            text_child.SetName(f"{name} value")
+
+    def _find_text_child(self, control: wx.Window) -> wx.Window | None:
+        for child in control.GetChildren():
+            class_name = getattr(child, "GetClassName", lambda: "")()
+            if class_name == "wxTextCtrl":
+                return child
+
+            nested = self._find_text_child(child)
+            if nested is not None:
+                return nested
+
+        return None
+
+    def _refresh_spin_contexts(self) -> None:
+        for spin in self._spin_controls:
+            self._set_spin_context(spin, spin.GetName())
+
+    def _on_window_create(self, event: wx.WindowCreateEvent) -> None:
+        self._refresh_spin_contexts()
+        event.Skip()
+
+    def _on_show(self, event: wx.ShowEvent) -> None:
+        if event.IsShown():
+            self._refresh_spin_contexts()
+            wx.CallAfter(self.notebook.SetFocus)
+        event.Skip()
 
     def _build_transfer_tab(self) -> None:
-        panel = wx.Panel(self.notebook)
-        grid = wx.FlexGridSizer(cols=2, vgap=8, hgap=8)
-        grid.AddGrowableCol(1, 1)
+        panel, sizer = self._new_tab_panel()
 
-        self.concurrent_spin = wx.SpinCtrl(panel, min=1, max=10)
-        self._add_field(
-            panel, grid, "&Concurrent transfers:", self.concurrent_spin, "Concurrent transfers"
+        self.concurrent_spin = self._register_spin(wx.SpinCtrl(panel, min=1, max=10), "Concurrent transfers")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Concurrent transfers:",
+            control=self.concurrent_spin,
+            control_name="Concurrent transfers",
         )
 
         self.overwrite_choice = wx.Choice(panel, choices=["ask", "overwrite", "skip", "rename"])
-        self._add_field(panel, grid, "&Overwrite mode:", self.overwrite_choice, "Overwrite mode")
-
-        self.resume_check = wx.CheckBox(panel, label="&Resume partial transfers")
-        self.resume_check.SetName("Resume partial transfers")
-        grid.Add((0, 0))
-        grid.Add(self.resume_check)
-
-        self.preserve_ts_check = wx.CheckBox(panel, label="&Preserve timestamps")
-        self.preserve_ts_check.SetName("Preserve timestamps")
-        grid.Add((0, 0))
-        grid.Add(self.preserve_ts_check)
-
-        self.follow_symlinks_check = wx.CheckBox(panel, label="&Follow symlinks")
-        self.follow_symlinks_check.SetName("Follow symlinks")
-        grid.Add((0, 0))
-        grid.Add(self.follow_symlinks_check)
-
-        self.download_dir_text = wx.TextCtrl(panel)
-        self._add_field(
-            panel, grid, "&Download directory:", self.download_dir_text, "Download directory"
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Overwrite mode:",
+            control=self.overwrite_choice,
+            control_name="Overwrite mode",
         )
 
-        panel.SetSizer(grid)
+        self.resume_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="&Resume partial transfers"),
+            name="Resume partial transfers",
+        )
+
+        self.preserve_ts_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="&Preserve timestamps"),
+            name="Preserve timestamps",
+        )
+
+        self.follow_symlinks_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="&Follow symlinks"),
+            name="Follow symlinks",
+        )
+
+        self.download_dir_text = wx.TextCtrl(panel)
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Download directory:",
+            control=self.download_dir_text,
+            control_name="Download directory",
+        )
+
+        sizer.AddStretchSpacer(1)
         self.notebook.AddPage(panel, "Transfer")
 
     def _build_display_tab(self) -> None:
-        panel = wx.Panel(self.notebook)
-        grid = wx.FlexGridSizer(cols=2, vgap=8, hgap=8)
-        grid.AddGrowableCol(1, 1)
+        panel, sizer = self._new_tab_panel()
 
-        self.announce_count_check = wx.CheckBox(panel, label="&Announce file count")
-        self.announce_count_check.SetName("Announce file count")
-        grid.Add((0, 0))
-        grid.Add(self.announce_count_check)
-
-        self.progress_interval_spin = wx.SpinCtrl(panel, min=5, max=50)
-        self._add_field(
-            panel, grid, "&Progress interval (%):", self.progress_interval_spin, "Progress interval"
+        self.announce_count_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="&Announce file count"),
+            name="Announce file count",
         )
 
-        self.show_hidden_check = wx.CheckBox(panel, label="Show &hidden files")
-        self.show_hidden_check.SetName("Show hidden files")
-        grid.Add((0, 0))
-        grid.Add(self.show_hidden_check)
+        self.progress_interval_spin = self._register_spin(
+            wx.SpinCtrl(panel, min=5, max=50), "Progress interval"
+        )
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Progress interval (%):",
+            control=self.progress_interval_spin,
+            control_name="Progress interval",
+        )
+
+        self.show_hidden_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="Show &hidden files"),
+            name="Show hidden files",
+        )
 
         self.sort_by_choice = wx.Choice(panel, choices=["name", "size", "modified", "type"])
-        self._add_field(panel, grid, "&Sort by:", self.sort_by_choice, "Sort by")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Sort by:",
+            control=self.sort_by_choice,
+            control_name="Sort by",
+        )
 
-        self.sort_asc_check = wx.CheckBox(panel, label="Sort &ascending")
-        self.sort_asc_check.SetName("Sort ascending")
-        grid.Add((0, 0))
-        grid.Add(self.sort_asc_check)
+        self.sort_asc_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="Sort &ascending"),
+            name="Sort ascending",
+        )
 
         self.date_format_choice = wx.Choice(panel, choices=["relative", "absolute"])
-        self._add_field(panel, grid, "&Date format:", self.date_format_choice, "Date format")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Date format:",
+            control=self.date_format_choice,
+            control_name="Date format",
+        )
 
-        panel.SetSizer(grid)
+        sizer.AddStretchSpacer(1)
         self.notebook.AddPage(panel, "Display")
 
     def _build_connection_tab(self) -> None:
-        panel = wx.Panel(self.notebook)
-        grid = wx.FlexGridSizer(cols=2, vgap=8, hgap=8)
-        grid.AddGrowableCol(1, 1)
+        panel, sizer = self._new_tab_panel()
 
         self.default_proto_choice = wx.Choice(panel, choices=["sftp", "ftp", "ftps"])
-        self._add_field(
-            panel, grid, "&Default protocol:", self.default_proto_choice, "Default protocol"
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Default protocol:",
+            control=self.default_proto_choice,
+            control_name="Default protocol",
         )
 
-        self.timeout_spin = wx.SpinCtrl(panel, min=5, max=300)
-        self._add_field(panel, grid, "&Timeout (seconds):", self.timeout_spin, "Timeout")
+        self.timeout_spin = self._register_spin(wx.SpinCtrl(panel, min=5, max=300), "Connection timeout")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Timeout (seconds):",
+            control=self.timeout_spin,
+            control_name="Connection timeout",
+        )
 
-        self.keepalive_spin = wx.SpinCtrl(panel, min=0, max=600)
-        self._add_field(panel, grid, "&Keepalive (seconds):", self.keepalive_spin, "Keepalive")
+        self.keepalive_spin = self._register_spin(wx.SpinCtrl(panel, min=0, max=600), "Keepalive interval")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Keepalive (seconds):",
+            control=self.keepalive_spin,
+            control_name="Keepalive interval",
+        )
 
-        self.retries_spin = wx.SpinCtrl(panel, min=0, max=10)
-        self._add_field(panel, grid, "Max &retries:", self.retries_spin, "Max retries")
+        self.retries_spin = self._register_spin(wx.SpinCtrl(panel, min=0, max=10), "Maximum retries")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="Max &retries:",
+            control=self.retries_spin,
+            control_name="Maximum retries",
+        )
 
-        self.passive_check = wx.CheckBox(panel, label="&Passive mode (FTP)")
-        self.passive_check.SetName("Passive mode")
-        grid.Add((0, 0))
-        grid.Add(self.passive_check)
+        self.passive_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="&Passive mode (FTP)"),
+            name="Passive mode",
+        )
 
         self.verify_keys_choice = wx.Choice(panel, choices=["ask", "always", "never"])
-        self._add_field(
-            panel, grid, "&Verify host keys:", self.verify_keys_choice, "Verify host keys"
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Verify host keys:",
+            control=self.verify_keys_choice,
+            control_name="Verify host keys",
         )
 
-        self.remember_local_folder_check = wx.CheckBox(
-            panel, label="&Remember last local folder on startup"
+        self.remember_local_folder_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="&Remember last local folder on startup"),
+            name="Remember last local folder on startup",
         )
-        self.remember_local_folder_check.SetName("Remember last local folder on startup")
-        grid.Add((0, 0))
-        grid.Add(self.remember_local_folder_check)
 
-        panel.SetSizer(grid)
+        sizer.AddStretchSpacer(1)
         self.notebook.AddPage(panel, "Connection")
 
     def _build_speech_tab(self) -> None:
-        panel = wx.Panel(self.notebook)
-        grid = wx.FlexGridSizer(cols=2, vgap=8, hgap=8)
-        grid.AddGrowableCol(1, 1)
+        panel, sizer = self._new_tab_panel()
 
-        self.speech_rate_spin = wx.SpinCtrl(panel, min=0, max=100)
-        self._add_field(panel, grid, "&Rate:", self.speech_rate_spin, "Speech rate")
+        self.speech_rate_spin = self._register_spin(wx.SpinCtrl(panel, min=0, max=100), "Speech rate")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Rate:",
+            control=self.speech_rate_spin,
+            control_name="Speech rate",
+        )
 
-        self.speech_volume_spin = wx.SpinCtrl(panel, min=0, max=100)
-        self._add_field(panel, grid, "&Volume:", self.speech_volume_spin, "Speech volume")
+        self.speech_volume_spin = self._register_spin(wx.SpinCtrl(panel, min=0, max=100), "Speech volume")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="&Volume:",
+            control=self.speech_volume_spin,
+            control_name="Speech volume",
+        )
 
         self.verbosity_choice = wx.Choice(panel, choices=["minimal", "normal", "verbose"])
-        self._add_field(panel, grid, "V&erbosity:", self.verbosity_choice, "Verbosity")
+        self._add_labeled_row(
+            panel,
+            sizer,
+            label="V&erbosity:",
+            control=self.verbosity_choice,
+            control_name="Speech verbosity",
+        )
 
-        panel.SetSizer(grid)
+        sizer.AddStretchSpacer(1)
         self.notebook.AddPage(panel, "Speech")
 
     def _populate(self) -> None:
         s = self._settings
-        # Transfer
+
         self.concurrent_spin.SetValue(s.transfer.concurrent_transfers)
-        idx = ["ask", "overwrite", "skip", "rename"].index(s.transfer.overwrite_mode)
-        self.overwrite_choice.SetSelection(idx)
+        self.overwrite_choice.SetSelection(["ask", "overwrite", "skip", "rename"].index(s.transfer.overwrite_mode))
         self.resume_check.SetValue(s.transfer.resume_partial)
         self.preserve_ts_check.SetValue(s.transfer.preserve_timestamps)
         self.follow_symlinks_check.SetValue(s.transfer.follow_symlinks)
         self.download_dir_text.SetValue(s.transfer.default_download_dir)
-        # Display
+
         self.announce_count_check.SetValue(s.display.announce_file_count)
         self.progress_interval_spin.SetValue(s.display.progress_interval)
         self.show_hidden_check.SetValue(s.display.show_hidden_files)
-        idx = ["name", "size", "modified", "type"].index(s.display.sort_by)
-        self.sort_by_choice.SetSelection(idx)
+        self.sort_by_choice.SetSelection(["name", "size", "modified", "type"].index(s.display.sort_by))
         self.sort_asc_check.SetValue(s.display.sort_ascending)
-        idx = ["relative", "absolute"].index(s.display.date_format)
-        self.date_format_choice.SetSelection(idx)
-        # Connection
-        idx = ["sftp", "ftp", "ftps"].index(s.connection.protocol)
-        self.default_proto_choice.SetSelection(idx)
+        self.date_format_choice.SetSelection(["relative", "absolute"].index(s.display.date_format))
+
+        self.default_proto_choice.SetSelection(["sftp", "ftp", "ftps"].index(s.connection.protocol))
         self.timeout_spin.SetValue(s.connection.timeout)
         self.keepalive_spin.SetValue(s.connection.keepalive)
         self.retries_spin.SetValue(s.connection.max_retries)
         self.passive_check.SetValue(s.connection.passive_mode)
-        idx = ["ask", "always", "never"].index(s.connection.verify_host_keys)
-        self.verify_keys_choice.SetSelection(idx)
+        self.verify_keys_choice.SetSelection(["ask", "always", "never"].index(s.connection.verify_host_keys))
         self.remember_local_folder_check.SetValue(s.app.remember_last_local_folder_on_startup)
-        # Speech
+
         self.speech_rate_spin.SetValue(s.speech.rate)
         self.speech_volume_spin.SetValue(s.speech.volume)
-        idx = ["minimal", "normal", "verbose"].index(s.speech.verbosity)
-        self.verbosity_choice.SetSelection(idx)
+        self.verbosity_choice.SetSelection(["minimal", "normal", "verbose"].index(s.speech.verbosity))
 
     def get_settings(self) -> Settings:
         """Return updated Settings from the dialog fields."""
@@ -215,12 +365,14 @@ class SettingsDialog(wx.Dialog):
         s.transfer.preserve_timestamps = self.preserve_ts_check.GetValue()
         s.transfer.follow_symlinks = self.follow_symlinks_check.GetValue()
         s.transfer.default_download_dir = self.download_dir_text.GetValue()
+
         s.display.announce_file_count = self.announce_count_check.GetValue()
         s.display.progress_interval = self.progress_interval_spin.GetValue()
         s.display.show_hidden_files = self.show_hidden_check.GetValue()
         s.display.sort_by = self.sort_by_choice.GetStringSelection()
         s.display.sort_ascending = self.sort_asc_check.GetValue()
         s.display.date_format = self.date_format_choice.GetStringSelection()
+
         s.connection.protocol = self.default_proto_choice.GetStringSelection()
         s.connection.timeout = self.timeout_spin.GetValue()
         s.connection.keepalive = self.keepalive_spin.GetValue()
@@ -228,6 +380,7 @@ class SettingsDialog(wx.Dialog):
         s.connection.passive_mode = self.passive_check.GetValue()
         s.connection.verify_host_keys = self.verify_keys_choice.GetStringSelection()
         s.app.remember_last_local_folder_on_startup = self.remember_local_folder_check.GetValue()
+
         s.speech.rate = self.speech_rate_spin.GetValue()
         s.speech.volume = self.speech_volume_spin.GetValue()
         s.speech.verbosity = self.verbosity_choice.GetStringSelection()

--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -25,7 +25,7 @@ class SettingsDialog(wx.Dialog):
         self.SetName("Settings Dialog")
 
         self.Bind(wx.EVT_SHOW, self._on_show)
-        self.Bind(wx.EVT_WINDOW_CREATE, self._on_window_create)
+        wx.CallAfter(self._refresh_spin_contexts)
 
     def _build_ui(self) -> None:
         root = wx.BoxSizer(wx.VERTICAL)
@@ -116,10 +116,6 @@ class SettingsDialog(wx.Dialog):
     def _refresh_spin_contexts(self) -> None:
         for spin in self._spin_controls:
             self._set_spin_context(spin, spin.GetName())
-
-    def _on_window_create(self, event: wx.WindowCreateEvent) -> None:
-        self._refresh_spin_contexts()
-        event.Skip()
 
     def _on_show(self, event: wx.ShowEvent) -> None:
         if event.IsShown():

--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -24,8 +24,9 @@ class SettingsDialog(wx.Dialog):
         self._populate()
         self.SetName("Settings Dialog")
 
-        self.Bind(wx.EVT_SHOW, self._on_show)
-        wx.CallAfter(self._refresh_spin_contexts)
+        # Keep initialization simple/stable across wx builds.
+        self._refresh_spin_contexts()
+        wx.CallAfter(self.notebook.SetFocus)
 
     def _build_ui(self) -> None:
         root = wx.BoxSizer(wx.VERTICAL)
@@ -117,11 +118,6 @@ class SettingsDialog(wx.Dialog):
         for spin in self._spin_controls:
             self._set_spin_context(spin, spin.GetName())
 
-    def _on_show(self, event: wx.ShowEvent) -> None:
-        if event.IsShown():
-            self._refresh_spin_contexts()
-            wx.CallAfter(self.notebook.SetFocus)
-        event.Skip()
 
     def _build_transfer_tab(self) -> None:
         panel, sizer = self._new_tab_panel()

--- a/tests/test_settings_dialog_a11y.py
+++ b/tests/test_settings_dialog_a11y.py
@@ -1,0 +1,290 @@
+"""Accessibility contracts for the Settings dialog."""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+import types
+
+from portkeydrop.settings import Settings
+
+
+class _FakeEvent:
+    def __init__(self, shown: bool = False):
+        self._shown = shown
+        self.skipped = False
+
+    def IsShown(self) -> bool:
+        return self._shown
+
+    def Skip(self) -> None:
+        self.skipped = True
+
+
+class _Window:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.children = []
+        self._name = ""
+        self.focused = False
+        if parent is not None and hasattr(parent, "children"):
+            parent.children.append(self)
+
+    def SetName(self, name: str) -> None:
+        self._name = name
+
+    def GetName(self) -> str:
+        return self._name
+
+    def SetFocus(self) -> None:
+        self.focused = True
+
+    def GetChildren(self):
+        return list(self.children)
+
+    def Bind(self, *_args, **_kwargs):
+        return None
+
+    def SetSizer(self, sizer):
+        self.sizer = sizer
+
+
+class _Dialog(_Window):
+    def __init__(self, parent=None, **_kwargs):
+        super().__init__(parent)
+
+    def CreateStdDialogButtonSizer(self, _flags):
+        return _BoxSizer()
+
+
+class _Panel(_Window):
+    pass
+
+
+class _Notebook(_Window):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.pages = []
+
+    def AddPage(self, panel, title: str):
+        self.pages.append((panel, title))
+
+
+class _BoxSizer:
+    def __init__(self, *_args, **_kwargs):
+        self.items = []
+
+    def Add(self, *args, **kwargs):
+        self.items.append((args, kwargs))
+
+    def AddStretchSpacer(self, *_args, **_kwargs):
+        return None
+
+
+class _Control(_Window):
+    def __init__(self, parent=None, **_kwargs):
+        super().__init__(parent)
+        self._value = None
+        self._selection = 0
+        self._tooltip = ""
+
+    def SetValue(self, value):
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+    def SetToolTip(self, text: str):
+        self._tooltip = text
+
+
+class _TextCtrl(_Control):
+    def GetClassName(self) -> str:
+        return "wxTextCtrl"
+
+
+class _SpinCtrl(_Control):
+    def __init__(self, parent=None, **_kwargs):
+        super().__init__(parent)
+        self._editor = _TextCtrl(self)
+
+
+class _Choice(_Control):
+    def __init__(self, parent=None, choices=None):
+        super().__init__(parent)
+        self._choices = choices or []
+
+    def SetSelection(self, idx: int):
+        self._selection = idx
+
+    def GetStringSelection(self) -> str:
+        return self._choices[self._selection]
+
+
+class _CheckBox(_Control):
+    pass
+
+
+class _StaticText(_Window):
+    created = []
+
+    def __init__(self, parent=None, label: str = ""):
+        super().__init__(parent)
+        self.label = label
+        self._label_for = None
+        _StaticText.created.append(self)
+
+    def SetMinSize(self, *_args, **_kwargs):
+        return None
+
+    def Wrap(self, *_args, **_kwargs):
+        return None
+
+    def SetLabelFor(self, ctrl):
+        self._label_for = ctrl
+
+
+class _WxModule(types.SimpleNamespace):
+    pass
+
+
+def _load_settings_dialog_module(monkeypatch):
+    fake_wx = _WxModule(
+        Dialog=_Dialog,
+        Window=_Window,
+        Panel=_Panel,
+        Notebook=_Notebook,
+        BoxSizer=_BoxSizer,
+        StaticText=_StaticText,
+        SpinCtrl=_SpinCtrl,
+        Choice=_Choice,
+        CheckBox=_CheckBox,
+        TextCtrl=_TextCtrl,
+        Control=_Control,
+        ShowEvent=_FakeEvent,
+        WindowCreateEvent=_FakeEvent,
+        EVT_SHOW=object(),
+        EVT_WINDOW_CREATE=object(),
+        DEFAULT_DIALOG_STYLE=1,
+        RESIZE_BORDER=2,
+        VERTICAL=1,
+        HORIZONTAL=2,
+        EXPAND=4,
+        ALL=8,
+        LEFT=16,
+        RIGHT=32,
+        TOP=64,
+        ALIGN_CENTER_VERTICAL=128,
+        OK=1,
+        CANCEL=2,
+        CallAfter=lambda fn, *a, **k: fn(*a, **k),
+    )
+    monkeypatch.setitem(sys.modules, "wx", fake_wx)
+    _StaticText.created = []
+    module = importlib.import_module("portkeydrop.dialogs.settings")
+    module = importlib.reload(module)
+    return module
+
+
+def test_settings_dialog_assigns_unambiguous_names_and_label_links(monkeypatch):
+    module = _load_settings_dialog_module(monkeypatch)
+    dlg = module.SettingsDialog(None, Settings())
+
+    expected_names = {
+        "concurrent_spin": "Concurrent transfers",
+        "overwrite_choice": "Overwrite mode",
+        "resume_check": "Resume partial transfers",
+        "preserve_ts_check": "Preserve timestamps",
+        "follow_symlinks_check": "Follow symlinks",
+        "download_dir_text": "Download directory",
+        "announce_count_check": "Announce file count",
+        "progress_interval_spin": "Progress interval",
+        "show_hidden_check": "Show hidden files",
+        "sort_by_choice": "Sort by",
+        "sort_asc_check": "Sort ascending",
+        "date_format_choice": "Date format",
+        "default_proto_choice": "Default protocol",
+        "timeout_spin": "Connection timeout",
+        "keepalive_spin": "Keepalive interval",
+        "retries_spin": "Maximum retries",
+        "passive_check": "Passive mode",
+        "verify_keys_choice": "Verify host keys",
+        "remember_local_folder_check": "Remember last local folder on startup",
+        "speech_rate_spin": "Speech rate",
+        "speech_volume_spin": "Speech volume",
+        "verbosity_choice": "Speech verbosity",
+    }
+
+    for attr, expected in expected_names.items():
+        control = getattr(dlg, attr)
+        assert control.GetName() == expected
+
+    linked_controls = {lbl._label_for for lbl in _StaticText.created if lbl._label_for is not None}
+    for attr in [
+        "concurrent_spin",
+        "overwrite_choice",
+        "download_dir_text",
+        "progress_interval_spin",
+        "sort_by_choice",
+        "date_format_choice",
+        "default_proto_choice",
+        "timeout_spin",
+        "keepalive_spin",
+        "retries_spin",
+        "verify_keys_choice",
+        "speech_rate_spin",
+        "speech_volume_spin",
+        "verbosity_choice",
+    ]:
+        assert getattr(dlg, attr) in linked_controls
+
+
+def test_spin_controls_name_inner_editor_with_field_context(monkeypatch):
+    module = _load_settings_dialog_module(monkeypatch)
+    dlg = module.SettingsDialog(None, Settings())
+
+    spin_controls = [
+        dlg.concurrent_spin,
+        dlg.progress_interval_spin,
+        dlg.timeout_spin,
+        dlg.keepalive_spin,
+        dlg.retries_spin,
+        dlg.speech_rate_spin,
+        dlg.speech_volume_spin,
+    ]
+
+    for spin in spin_controls:
+        editor = spin.GetChildren()[0]
+        assert editor.GetName() == f"{spin.GetName()} value"
+
+
+def test_settings_dialog_focuses_tab_control_on_show(monkeypatch):
+    module = _load_settings_dialog_module(monkeypatch)
+    dlg = module.SettingsDialog(None, Settings())
+
+    show_event = _FakeEvent(shown=True)
+    dlg._on_show(show_event)
+
+    assert dlg.notebook.focused is True
+    assert show_event.skipped is True
+
+
+def test_menu_bar_order_contract_not_changed():
+    app_py = ("src/portkeydrop/app.py")
+    with open(app_py, encoding="utf-8") as f:
+        source = f.read()
+
+    expected = [
+        'menubar.Append(file_menu, "&File")',
+        'menubar.Append(sites_menu, "S&ites")',
+        'menubar.Append(transfer_menu, "&Transfer")',
+        'menubar.Append(view_menu, "&View")',
+        'menubar.Append(edit_menu, "&Edit")',
+        'menubar.Append(help_menu, "&Help")',
+    ]
+
+    positions = [source.index(fragment) for fragment in expected]
+    assert positions == sorted(positions)
+
+    assert re.search(r'file_menu\.Append\(ID_SETTINGS, "Se&ttings\.\.\."', source)

--- a/tests/test_settings_dialog_a11y.py
+++ b/tests/test_settings_dialog_a11y.py
@@ -259,15 +259,11 @@ def test_spin_controls_name_inner_editor_with_field_context(monkeypatch):
         assert editor.GetName() == f"{spin.GetName()} value"
 
 
-def test_settings_dialog_focuses_tab_control_on_show(monkeypatch):
+def test_settings_dialog_focuses_tab_control_on_open(monkeypatch):
     module = _load_settings_dialog_module(monkeypatch)
     dlg = module.SettingsDialog(None, Settings())
 
-    show_event = _FakeEvent(shown=True)
-    dlg._on_show(show_event)
-
     assert dlg.notebook.focused is True
-    assert show_event.skipped is True
 
 
 def test_menu_bar_order_contract_not_changed():


### PR DESCRIPTION
## Summary
- rebuild the settings dialog structure using clean row-based tab layouts (Transfer, Display, Connection, Speech)
- preserve all existing settings fields and get/save behavior
- enforce clearer accessibility naming on every control and associated label
- add spin-control context propagation to inner text editor children for better NVDA announcements
- ensure initial focus is sent to the tab control when the dialog opens

## Tests
- `PYTHONPATH=src pytest -q tests/test_settings.py tests/test_settings_dialog_a11y.py`
- `PYTHONPATH=src pytest -q tests/test_settings_dialog_a11y.py`

## Notes
- this branch intentionally does not modify menu construction behavior; added a regression contract test for menu order and Settings entry label in `app.py`
- full project test run is currently blocked in this environment by missing optional runtime dependency (`paramiko`) used by unrelated SSH/SFTP tests
