### PR TITLE
fix(sites): clearing password now removes it from keyring (#15)

### DIFF
--- a/src/portkeydrop/sites.py
+++ b/src/portkeydrop/sites.py
@@ -220,6 +220,10 @@ class SiteManager:
         for site in self._sites:
             if site.password:
                 self._passwords.store(site.id, site.password)
+            else:
+                # Password was cleared — remove it from secure storage so it
+                # doesn't get restored from keyring/vault on next load()
+                self._passwords.delete(site.id)
         data = []
         for site in self._sites:
             d = asdict(site)


### PR DESCRIPTION
Fixes #15.\n\nWhen saving a site with an empty password, the old password was never deleted from keyring/vault — it would be restored silently on next load. Added `else: self._passwords.delete(site.id)` to the save loop.