### PR TITLE
fix(ssh): identify as PortkeyDrop in SSH banner

### DIFF
--- a/src/portkeydrop/dialogs/host_key_dialog.py
+++ b/src/portkeydrop/dialogs/host_key_dialog.py
@@ -20,9 +20,7 @@ class HostKeyDialog(sc.SizedDialog):
         pane = self.GetContentsPane()
         pane.SetSizerType("vertical")
 
-        wx.StaticText(
-            pane, label=f"The host key for {hostname!r} is not in your known hosts."
-        )
+        wx.StaticText(pane, label=f"The host key for {hostname!r} is not in your known hosts.")
         wx.StaticText(pane, label=f"Key type: {key_type}")
         wx.StaticText(pane, label=f"Fingerprint: {fingerprint}")
         wx.StaticText(pane, label="Do you want to connect?")
@@ -34,9 +32,7 @@ class HostKeyDialog(sc.SizedDialog):
         accept_once_btn = wx.Button(btn_pane, label="Accept &Once")
         reject_btn = wx.Button(btn_pane, label="&Reject")
 
-        accept_perm_btn.Bind(
-            wx.EVT_BUTTON, lambda e: self.EndModal(self.ACCEPT_PERMANENT)
-        )
+        accept_perm_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(self.ACCEPT_PERMANENT))
         accept_once_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(self.ACCEPT_ONCE))
         reject_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(self.REJECT))
 

--- a/src/portkeydrop/host_key_policy.py
+++ b/src/portkeydrop/host_key_policy.py
@@ -16,6 +16,7 @@ except Exception:  # pragma: no cover - exercised in headless tests
 try:
     from portkeydrop.dialogs.host_key_dialog import HostKeyDialog
 except Exception:  # pragma: no cover - wx may be unavailable in headless tests
+
     class HostKeyDialog:  # type: ignore[no-redef]
         REJECT = 0
         ACCEPT_ONCE = 1

--- a/src/portkeydrop/protocols.py
+++ b/src/portkeydrop/protocols.py
@@ -16,6 +16,7 @@ from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, BinaryIO, Callable
 
 from portkeydrop.host_key_policy import InteractiveHostKeyPolicy
+import portkeydrop.ssh_utils as _ssh_utils  # noqa: F401 — imported for side-effect (SSH banner patch)
 
 if TYPE_CHECKING:
     import paramiko

--- a/src/portkeydrop/ssh_utils.py
+++ b/src/portkeydrop/ssh_utils.py
@@ -11,6 +11,20 @@ import platform
 
 import paramiko
 
+from portkeydrop import __version__
+
+# Patch Paramiko's SSH banner so server logs show "PortkeyDrop" instead of
+# "paramiko". This runs once at import time and affects all Transports.
+_original_transport_init = paramiko.Transport.__init__
+
+
+def _portkeydrop_transport_init(self, *args, **kwargs):
+    _original_transport_init(self, *args, **kwargs)
+    self.local_version = f"SSH-2.0-PortkeyDrop_{__version__}"
+
+
+paramiko.Transport.__init__ = _portkeydrop_transport_init
+
 
 def check_ssh_agent_available() -> bool:
     """Check whether an SSH agent is available on the current platform.

--- a/tests/test_host_key_dialog.py
+++ b/tests/test_host_key_dialog.py
@@ -1,0 +1,179 @@
+"""Tests for HostKeyDialog (headless, wx-stubbed)."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+# ---------------------------------------------------------------------------
+# Minimal wx / wx.lib.sized_controls stubs for headless testing
+# ---------------------------------------------------------------------------
+
+
+class _Window:
+    def __init__(self, parent=None, **_kw):
+        self.parent = parent
+        self.children: list[_Window] = []
+        self._bound: list[tuple] = []
+        self._focused = False
+        if parent is not None and hasattr(parent, "children"):
+            parent.children.append(self)
+
+    def Bind(self, event, handler):
+        self._bound.append((event, handler))
+
+    def SetFocus(self) -> None:
+        self._focused = True
+
+    def Fit(self) -> None:
+        pass
+
+    def SetMinSize(self, _size) -> None:
+        pass
+
+    def EndModal(self, result: int) -> None:
+        self._modal_result = result
+
+
+class _SizedDialog(_Window):
+    def __init__(self, parent=None, title: str = "", style: int = 0, **_kw):
+        super().__init__(parent)
+        self.title = title
+        self._pane = _SizedPanel(self)
+
+    def GetContentsPane(self) -> "_SizedPanel":
+        return self._pane
+
+
+class _SizedPanel(_Window):
+    def SetSizerType(self, _sizer_type: str) -> None:
+        pass
+
+
+class _StaticText(_Window):
+    created: list["_StaticText"] = []
+
+    def __init__(self, parent=None, label: str = "", **_kw):
+        super().__init__(parent)
+        self.label = label
+        _StaticText.created.append(self)
+
+
+class _Button(_Window):
+    def __init__(self, parent=None, label: str = "", **_kw):
+        super().__init__(parent)
+        self.label = label
+
+
+_EVT_BUTTON = object()
+
+
+def _make_wx_modules():
+    """Build a fake wx module tree that supports `import wx.lib.sized_controls as sc`."""
+    # wx.lib.sized_controls
+    fake_sc = types.ModuleType("wx.lib.sized_controls")
+    fake_sc.SizedDialog = _SizedDialog
+    fake_sc.SizedPanel = _SizedPanel
+
+    # wx.lib
+    fake_lib = types.ModuleType("wx.lib")
+    fake_lib.sized_controls = fake_sc
+
+    # wx (top-level) — must be a ModuleType so `wx.lib` attribute access works
+    fake_wx = types.ModuleType("wx")
+    fake_wx.DEFAULT_DIALOG_STYLE = 1
+    fake_wx.RESIZE_BORDER = 2
+    fake_wx.StaticText = _StaticText
+    fake_wx.Button = _Button
+    fake_wx.EVT_BUTTON = _EVT_BUTTON
+    fake_wx.lib = fake_lib
+
+    return fake_wx, fake_lib, fake_sc
+
+
+def _load_host_key_dialog(monkeypatch):
+    """Import HostKeyDialog with fake wx and return the class."""
+    fake_wx, fake_lib, fake_sc = _make_wx_modules()
+    monkeypatch.setitem(sys.modules, "wx", fake_wx)
+    monkeypatch.setitem(sys.modules, "wx.lib", fake_lib)
+    monkeypatch.setitem(sys.modules, "wx.lib.sized_controls", fake_sc)
+    _StaticText.created = []
+
+    sys.modules.pop("portkeydrop.dialogs.host_key_dialog", None)
+    mod = importlib.import_module("portkeydrop.dialogs.host_key_dialog")
+    return mod.HostKeyDialog
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHostKeyDialogConstants:
+    def test_reject_is_zero(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        assert dlg_cls.REJECT == 0
+
+    def test_accept_once_is_one(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        assert dlg_cls.ACCEPT_ONCE == 1
+
+    def test_accept_permanent_is_two(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        assert dlg_cls.ACCEPT_PERMANENT == 2
+
+
+class TestHostKeyDialogInit:
+    def test_creates_host_label_with_hostname(self, monkeypatch):
+        """Line 23: StaticText displays the unknown hostname."""
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg_cls(None, "example.com", "ssh-rsa", "aa:bb:cc:dd")
+        labels = [s.label for s in _StaticText.created]
+        assert any("example.com" in lbl for lbl in labels)
+
+    def test_creates_key_type_label(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg_cls(None, "host.test", "ecdsa-sha2-nistp256", "ff:ee:dd")
+        labels = [s.label for s in _StaticText.created]
+        assert any("ecdsa-sha2-nistp256" in lbl for lbl in labels)
+
+    def test_creates_fingerprint_label(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg_cls(None, "host.test", "ssh-ed25519", "de:ad:be:ef")
+        labels = [s.label for s in _StaticText.created]
+        assert any("de:ad:be:ef" in lbl for lbl in labels)
+
+    def test_accept_permanent_button_bind(self, monkeypatch):
+        """Line 35: Accept Permanently button binds a handler."""
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg = dlg_cls(None, "example.com", "ssh-rsa", "aa:bb:cc")
+        # Accept Permanently is the first button; verify it has a Bind
+        pane = dlg._pane
+        btn_pane = next(c for c in pane.children if isinstance(c, _SizedPanel))
+        buttons = [c for c in btn_pane.children if isinstance(c, _Button)]
+        accept_perm = buttons[0]
+        assert len(accept_perm._bound) == 1, "Accept Permanently button should have one handler"
+
+    def test_accept_permanent_handler_calls_end_modal(self, monkeypatch):
+        """Invoking the Accept Permanently handler ends modal with ACCEPT_PERMANENT."""
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg = dlg_cls(None, "example.com", "ssh-rsa", "aa:bb:cc")
+        pane = dlg._pane
+        btn_pane = next(c for c in pane.children if isinstance(c, _SizedPanel))
+        buttons = [c for c in btn_pane.children if isinstance(c, _Button)]
+        accept_perm = buttons[0]
+        _event, handler = accept_perm._bound[0]
+        handler(None)  # simulate button click
+        assert dlg._modal_result == dlg_cls.ACCEPT_PERMANENT
+
+    def test_all_three_buttons_bound(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg = dlg_cls(None, "example.com", "ssh-rsa", "aa:bb:cc")
+        pane = dlg._pane
+        btn_pane = next(c for c in pane.children if isinstance(c, _SizedPanel))
+        buttons = [c for c in btn_pane.children if isinstance(c, _Button)]
+        assert len(buttons) == 3
+        for btn in buttons:
+            assert len(btn._bound) == 1

--- a/tests/test_host_key_policy.py
+++ b/tests/test_host_key_policy.py
@@ -66,9 +66,7 @@ class TestInteractiveHostKeyPolicy:
         import portkeydrop.host_key_policy as host_key_policy
 
         monkeypatch.setattr(host_key_policy, "HostKeyDialog", AcceptOnceDialog)
-        monkeypatch.setattr(
-            host_key_policy.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw)
-        )
+        monkeypatch.setattr(host_key_policy.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
 
         policy = InteractiveHostKeyPolicy(None, "/tmp/known_hosts")
         key = MagicMock()
@@ -101,9 +99,7 @@ class TestInteractiveHostKeyPolicy:
         import portkeydrop.host_key_policy as host_key_policy
 
         monkeypatch.setattr(host_key_policy, "HostKeyDialog", AcceptPermanentDialog)
-        monkeypatch.setattr(
-            host_key_policy.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw)
-        )
+        monkeypatch.setattr(host_key_policy.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
 
         policy = InteractiveHostKeyPolicy(None, "/tmp/known_hosts")
         key = MagicMock()
@@ -136,9 +132,7 @@ class TestInteractiveHostKeyPolicy:
         import portkeydrop.host_key_policy as host_key_policy
 
         monkeypatch.setattr(host_key_policy, "HostKeyDialog", RejectDialog)
-        monkeypatch.setattr(
-            host_key_policy.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw)
-        )
+        monkeypatch.setattr(host_key_policy.wx, "CallAfter", lambda fn, *a, **kw: fn(*a, **kw))
 
         policy = InteractiveHostKeyPolicy(None, "/tmp/known_hosts")
         key = MagicMock()

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -6,7 +6,12 @@ from unittest import mock
 
 import paramiko
 
-from portkeydrop.ssh_utils import check_ssh_agent_available, create_ssh_client
+from portkeydrop import __version__
+from portkeydrop.ssh_utils import (
+    _portkeydrop_transport_init,
+    check_ssh_agent_available,
+    create_ssh_client,
+)
 
 
 class TestCheckSshAgentAvailable:
@@ -81,3 +86,21 @@ class TestCreateSshClient:
         client = create_ssh_client()
         assert client._allow_agent is True  # type: ignore[attr-defined]
         assert client._look_for_keys is True  # type: ignore[attr-defined]
+
+
+class TestSshBannerPatch:
+    """Tests for the paramiko Transport banner patch."""
+
+    def test_banner_patch_sets_local_version(self):
+        """_portkeydrop_transport_init patches local_version on the transport."""
+        mock_self = mock.MagicMock()
+        with mock.patch("portkeydrop.ssh_utils._original_transport_init"):
+            _portkeydrop_transport_init(mock_self)
+        assert mock_self.local_version == f"SSH-2.0-PortkeyDrop_{__version__}"
+
+    def test_banner_patch_calls_original_init(self):
+        """_portkeydrop_transport_init delegates to the original __init__."""
+        mock_self = mock.MagicMock()
+        with mock.patch("portkeydrop.ssh_utils._original_transport_init") as orig:
+            _portkeydrop_transport_init(mock_self, "arg1", kw="val")
+        orig.assert_called_once_with(mock_self, "arg1", kw="val")


### PR DESCRIPTION
Server logs previously showed `SSH-2.0-paramiko_x.x.x` as the client version string. Patches `paramiko.Transport.__init__` at import time so server admins see `SSH-2.0-PortkeyDrop_0.1.0` instead.