### PR TITLE
ci: fix git-cliff release notes generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,7 @@ jobs:
           IS_NIGHTLY: ${{ needs.prepare.outputs.is_nightly }}
           VERSION: ${{ needs.prepare.outputs.version }}
           TAG: ${{ needs.prepare.outputs.tag }}
+          CLIFF_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p assets
           TIMESTAMP=$(date -u +%Y%m%d)
@@ -184,7 +185,7 @@ jobs:
           else
             PREV_TAG=$(git tag --list "v[0-9]*" --sort=-version:refname | grep -v "v${VERSION}" | head -1)
             npx git-cliff@latest ${PREV_TAG:+"$PREV_TAG"..HEAD} --tag "v${VERSION}" \
-              --ignore-tags "nightly-.*" --strip header --strip all 2>/dev/null > notes.md || true
+              --ignore-tags "nightly-.*" --strip all > notes.md || true
             if [ ! -s notes.md ]; then
               echo "See [CHANGELOG.md](https://github.com/Orinks/PortkeyDrop/blob/main/CHANGELOG.md) for full release notes." > notes.md
             fi


### PR DESCRIPTION
## Problem

Stable release notes were always falling back to the generic CHANGELOG.md link instead of generating proper notes via git-cliff. Two bugs in the release workflow caused this:

1. **Duplicate `--strip` flag** — `--strip header --strip all` passes the flag twice. The second value (`all`) overrides the first, but depending on the git-cliff version, duplicate flags may cause an error exit. Stderr was suppressed with `2>/dev/null` so the failure was silent and `notes.md` stayed empty.

2. **Missing `CLIFF_GITHUB_TOKEN`** — `cliff.toml` has `[remote.github]` configured. Without a token, git-cliff may fail to resolve GitHub metadata.

## Fix

- Drop `--strip header` (redundant — `--strip all` already strips both header and footer)
- Add `CLIFF_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the Prepare release env
- Remove `2>/dev/null` so any future git-cliff errors are visible in CI logs

## Result

Release notes for stable tags will now look like:

```
### Fixed
- Sftp: implement interactive host key prompt for prompt policy
- Sites: clearing password now deletes it from keyring/vault
- App: wire verify_host_keys setting to host key policy on connect
- App: run connect() in background thread to prevent deadlock
- Ssh: identify as PortkeyDrop in SSH banner
```