### PR TITLE
ci: use git-cliff for nightly notes, dedup duplicate entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,15 +169,13 @@ jobs:
           # Generate checksums
           cd assets && sha256sum * > checksums.txt 2>/dev/null || true
 
-          # Generate release notes
+          # Generate release notes via git-cliff (nightly and stable)
           cd ..
           if [ "$IS_NIGHTLY" = "true" ]; then
             LAST_TAG=$(git tag --list "nightly-*" --sort=-version:refname | head -1)
             if [ -n "$LAST_TAG" ]; then
-              git log "$LAST_TAG"..HEAD --oneline --no-merges --first-parent | \
-                grep -Ei '^[a-f0-9]+ (feat|fix|perf|security)(\([^)]+\))?:' | \
-                grep -Eiv '^[a-f0-9]+ fix\((test|ci|build|chore|docs|style|refactor)\):' | \
-                sed 's/^/- /' > notes.md
+              npx git-cliff@latest "$LAST_TAG"..HEAD --strip all > notes.md.tmp || true
+              awk '!seen[$0]++' notes.md.tmp > notes.md && rm -f notes.md.tmp
               [ -s notes.md ] || echo "- No user-facing changes" > notes.md
             else
               echo "Initial nightly build" > notes.md
@@ -185,7 +183,8 @@ jobs:
           else
             PREV_TAG=$(git tag --list "v[0-9]*" --sort=-version:refname | grep -v "v${VERSION}" | head -1)
             npx git-cliff@latest ${PREV_TAG:+"$PREV_TAG"..HEAD} --tag "v${VERSION}" \
-              --ignore-tags "nightly-.*" --strip all > notes.md || true
+              --ignore-tags "nightly-.*" --strip all > notes.md.tmp || true
+            awk '!seen[$0]++' notes.md.tmp > notes.md && rm -f notes.md.tmp
             if [ ! -s notes.md ]; then
               echo "See [CHANGELOG.md](https://github.com/Orinks/PortkeyDrop/blob/main/CHANGELOG.md) for full release notes." > notes.md
             fi


### PR DESCRIPTION
Brings nightly release notes up to the same quality as stable releases, and prevents duplicate lines.

## Changes

**Nightlies**: replace the raw `git log` grep (flat bullet list with commit hashes) with git-cliff, giving the same grouped `### Fixed` / `### Added` format.

**Both nightly + stable**: pipe git-cliff output through `awk '!seen[$0]++'` to deduplicate identical lines. This handles cases where multiple commits in a PR share the same subject (e.g. two fix commits with the same message produce the same bullet point).