### PR TITLE
chore: add pre-commit config with ruff and standard hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: debug-statements
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.3
+    hooks:
+    -   id: ruff
+        args: [--fix]
+        files: ^(src/|tests/)
+    -   id: ruff-format
+        files: ^(src/|tests/)


### PR DESCRIPTION
Adds `.pre-commit-config.yaml` matching the setup used in AccessiWeather.

**Hooks:** trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, debug-statements, ruff (lint+fix), ruff-format.

All existing files pass clean.