### PR TITLE
fix(a11y): HostKeyDialog focus/escape, refresh focus guard, F6/Ctrl+L pane navigation

### DIFF
--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -64,6 +64,8 @@ ID_FILTER = wx.NewIdRef()
 ID_SAVE_CONNECTION = wx.NewIdRef()
 ID_SETTINGS = wx.NewIdRef()
 ID_IMPORT_CONNECTIONS = wx.NewIdRef()
+ID_SWITCH_PANE_FOCUS = wx.NewIdRef()
+ID_FOCUS_ADDRESS_BAR = wx.NewIdRef()
 
 
 class MainFrame(wx.Frame):
@@ -339,6 +341,8 @@ class MainFrame(wx.Frame):
         self.Bind(wx.EVT_MENU, self._on_transfer_queue, id=ID_TRANSFER_QUEUE)
         self.Bind(wx.EVT_MENU, self._on_settings, id=ID_SETTINGS)
         self.Bind(wx.EVT_MENU, self._on_import_connections, id=ID_IMPORT_CONNECTIONS)
+        self.Bind(wx.EVT_MENU, self._on_switch_pane_focus, id=ID_SWITCH_PANE_FOCUS)
+        self.Bind(wx.EVT_MENU, self._on_focus_address_bar, id=ID_FOCUS_ADDRESS_BAR)
         self.Bind(wx.EVT_MENU, self._on_about, id=wx.ID_ABOUT)
         self.Bind(get_transfer_event_binder(), self._on_transfer_update)
 
@@ -358,6 +362,13 @@ class MainFrame(wx.Frame):
         # Path bar enter
         self.local_path_bar.Bind(wx.EVT_TEXT_ENTER, self._on_local_path_enter)
         self.remote_path_bar.Bind(wx.EVT_TEXT_ENTER, self._on_remote_path_enter)
+
+        # Global accelerators for pane navigation and toolbar focus
+        entries = [
+            wx.AcceleratorEntry(wx.ACCEL_NORMAL, wx.WXK_F6, ID_SWITCH_PANE_FOCUS),
+            wx.AcceleratorEntry(wx.ACCEL_CTRL, ord("L"), ID_FOCUS_ADDRESS_BAR),
+        ]
+        self.SetAcceleratorTable(wx.AcceleratorTable(entries))
 
     def _on_toolbar_protocol_change(self, event: wx.CommandEvent) -> None:
         proto = self.tb_protocol.GetStringSelection()
@@ -616,6 +627,19 @@ class MainFrame(wx.Frame):
         else:
             self._refresh_remote_files()
 
+    def _on_switch_pane_focus(self, event: wx.CommandEvent) -> None:
+        focused = self.FindFocus()
+        if focused is self.local_file_list:
+            self.remote_file_list.SetFocus()
+            self._announce("Remote Files pane")
+            return
+        self.local_file_list.SetFocus()
+        self._announce("Local Files pane")
+
+    def _on_focus_address_bar(self, event: wx.CommandEvent) -> None:
+        self.tb_host.SetFocus()
+        self._announce("Address bar")
+
     def _refresh_remote_files(self) -> None:
         if not self._client or not self._client.connected:
             return
@@ -632,6 +656,7 @@ class MainFrame(wx.Frame):
         threading.Thread(target=_worker, daemon=True).start()
 
     def _on_remote_files_loaded(self, files: list[RemoteFile], cwd: str) -> None:
+        restore_focus = self.FindFocus() is self.remote_file_list
         self._apply_sort(files)
         # Insert ".." entry at the top to navigate to parent
         if cwd != "/":
@@ -650,7 +675,8 @@ class MainFrame(wx.Frame):
         if self.remote_file_list.GetItemCount() > 0:
             self.remote_file_list.Select(0)
             self.remote_file_list.Focus(0)
-            self.remote_file_list.SetFocus()
+            if restore_focus:
+                self.remote_file_list.SetFocus()
         count = len(self._get_visible_files(self._remote_files, self._remote_filter_text))
         if self._settings.display.announce_file_count:
             self._announce(f"{cwd}: {count} items")
@@ -665,6 +691,7 @@ class MainFrame(wx.Frame):
         wx.MessageBox(msg, "Error", wx.OK | wx.ICON_ERROR, self)
 
     def _refresh_local_files(self) -> None:
+        restore_focus = self.FindFocus() is self.local_file_list
         try:
             self._local_files = list_local_dir(self._local_cwd)
             self._apply_sort(self._local_files)
@@ -682,7 +709,8 @@ class MainFrame(wx.Frame):
             if self.local_file_list.GetItemCount() > 0:
                 self.local_file_list.Select(0)
                 self.local_file_list.Focus(0)
-                self.local_file_list.SetFocus()
+                if restore_focus:
+                    self.local_file_list.SetFocus()
             count = len(self._get_visible_files(self._local_files, self._local_filter_text))
             if self._settings.display.announce_file_count:
                 self._announce(f"{self._local_cwd}: {count} items")

--- a/src/portkeydrop/dialogs/host_key_dialog.py
+++ b/src/portkeydrop/dialogs/host_key_dialog.py
@@ -1,5 +1,7 @@
 """Dialog for unknown SSH host keys."""
 
+from __future__ import annotations
+
 import wx
 import wx.lib.sized_controls as sc
 
@@ -17,12 +19,19 @@ class HostKeyDialog(sc.SizedDialog):
             title="Unknown Host Key",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
+        self.SetName("Unknown Host Key")
         pane = self.GetContentsPane()
         pane.SetSizerType("vertical")
 
-        wx.StaticText(pane, label=f"The host key for {hostname!r} is not in your known hosts.")
-        wx.StaticText(pane, label=f"Key type: {key_type}")
-        wx.StaticText(pane, label=f"Fingerprint: {fingerprint}")
+        wx.StaticText(pane, label="The server identity could not be verified.")
+        security_text = f"Host: {hostname}\nKey type: {key_type}\nFingerprint: {fingerprint}"
+        self.security_details = wx.TextCtrl(
+            pane,
+            value=security_text,
+            style=wx.TE_MULTILINE | wx.TE_READONLY,
+            size=(450, 90),
+        )
+        self.security_details.SetName("Host key details")
         wx.StaticText(pane, label="Do you want to connect?")
 
         btn_pane = sc.SizedPanel(pane)
@@ -30,12 +39,19 @@ class HostKeyDialog(sc.SizedDialog):
 
         accept_perm_btn = wx.Button(btn_pane, label="&Accept Permanently")
         accept_once_btn = wx.Button(btn_pane, label="Accept &Once")
-        reject_btn = wx.Button(btn_pane, label="&Reject")
+        reject_btn = wx.Button(btn_pane, id=wx.ID_NO, label="&Reject")
 
         accept_perm_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(self.ACCEPT_PERMANENT))
         accept_once_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(self.ACCEPT_ONCE))
         reject_btn.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(self.REJECT))
+        self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
 
         self.Fit()
         self.SetMinSize((400, 200))
-        reject_btn.SetFocus()
+        self.security_details.SetFocus()
+
+    def _on_char_hook(self, event: wx.KeyEvent) -> None:
+        if event.GetKeyCode() == wx.WXK_ESCAPE:
+            self.EndModal(self.REJECT)
+            return
+        event.Skip()

--- a/tests/_wx_stub.py
+++ b/tests/_wx_stub.py
@@ -23,6 +23,9 @@ class _FakeFrame:
     def SetSizer(self, *_args, **_kwargs) -> None:
         pass
 
+    def SetAcceleratorTable(self, table) -> None:
+        self._accelerator_table = table
+
     def CreateStatusBar(self, *args, **kwargs):
         status = MagicMock(SetStatusText=MagicMock())
         self.status_bar = status
@@ -120,6 +123,9 @@ def _create_fake_wx() -> tuple[types.ModuleType, types.ModuleType]:
     fake_wx.WXK_BACK = 513
     fake_wx.WXK_DELETE = 514
     fake_wx.WXK_F2 = 515
+    fake_wx.WXK_F6 = 516
+    fake_wx.ACCEL_NORMAL = 1
+    fake_wx.ACCEL_CTRL = 2
     fake_wx.ID_OK = 100
     fake_wx.OK = 100
     fake_wx.YES = 101
@@ -159,6 +165,8 @@ def _create_fake_wx() -> tuple[types.ModuleType, types.ModuleType]:
 
     fake_wx.Dialog = _SimpleWidget
     fake_wx.TextEntryDialog = lambda *args, **kwargs: _SimpleWidget()
+    fake_wx.AcceleratorEntry = lambda flags, key_code, command: (flags, key_code, command)
+    fake_wx.AcceleratorTable = lambda entries: tuple(entries)
 
     fake_adv = types.ModuleType("wx.adv")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,6 +56,7 @@ def _hydrate_frame(module):
     frame._announce = MagicMock()
     frame._update_status = MagicMock()
     frame._show_transfer_queue = MagicMock()
+    frame._refresh_local_files = MagicMock()
     frame._refresh_remote_files = MagicMock()
     frame._get_selected_local_file = MagicMock()
     frame._get_selected_remote_file = MagicMock()
@@ -89,6 +90,68 @@ def test_bind_events_hooks_transfer_update(app_module):
         call.args[0] == binder and call.args[1] == frame._on_transfer_update
         for call in frame.Bind.call_args_list
     )
+
+
+def test_bind_events_sets_f6_and_ctrl_l_accelerators(app_module):
+    app, fake_wx = app_module
+    frame = object.__new__(app.MainFrame)
+    frame.Bind = MagicMock()
+    frame.SetAcceleratorTable = MagicMock()
+    frame.tb_connect_btn = MagicMock(Bind=MagicMock())
+    frame.tb_protocol = MagicMock(Bind=MagicMock())
+    frame.remote_file_list = MagicMock(Bind=MagicMock())
+    frame.local_file_list = MagicMock(Bind=MagicMock())
+    frame.local_path_bar = MagicMock(Bind=MagicMock())
+    frame.remote_path_bar = MagicMock(Bind=MagicMock())
+
+    with patch.object(app, "get_transfer_event_binder", return_value=object()):
+        frame._bind_events()
+
+    frame.SetAcceleratorTable.assert_called_once()
+    table_entries = frame.SetAcceleratorTable.call_args.args[0]
+    assert (
+        fake_wx.ACCEL_NORMAL,
+        fake_wx.WXK_F6,
+        app.ID_SWITCH_PANE_FOCUS,
+    ) in table_entries
+    assert (fake_wx.ACCEL_CTRL, ord("L"), app.ID_FOCUS_ADDRESS_BAR) in table_entries
+
+
+def test_switch_pane_focus_local_to_remote_announces(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame.local_file_list = MagicMock(SetFocus=MagicMock())
+    frame.remote_file_list = MagicMock(SetFocus=MagicMock())
+    frame.FindFocus = MagicMock(return_value=frame.local_file_list)
+
+    frame._on_switch_pane_focus(None)
+
+    frame.remote_file_list.SetFocus.assert_called_once()
+    frame._announce.assert_called_once_with("Remote Files pane")
+
+
+def test_switch_pane_focus_remote_to_local_announces(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame.local_file_list = MagicMock(SetFocus=MagicMock())
+    frame.remote_file_list = MagicMock(SetFocus=MagicMock())
+    frame.FindFocus = MagicMock(return_value=frame.remote_file_list)
+
+    frame._on_switch_pane_focus(None)
+
+    frame.local_file_list.SetFocus.assert_called_once()
+    frame._announce.assert_called_once_with("Local Files pane")
+
+
+def test_focus_address_bar_sets_toolbar_host_focus_and_announces(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame.tb_host = MagicMock(SetFocus=MagicMock())
+
+    frame._on_focus_address_bar(None)
+
+    frame.tb_host.SetFocus.assert_called_once()
+    frame._announce.assert_called_once_with("Address bar")
 
 
 def test_on_upload_directory_updates_status(app_module):
@@ -415,6 +478,56 @@ def test_on_remote_files_loaded_populates_list(app_module):
     frame.remote_path_bar.SetValue.assert_called_with("/home/user")
 
 
+def test_on_remote_files_loaded_does_not_steal_focus(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+
+    from portkeydrop.protocols import RemoteFile
+
+    frame._client = MagicMock(cwd="/home/user")
+    frame._remote_filter_text = ""
+    frame._settings = MagicMock()
+    frame._settings.display.announce_file_count = False
+    frame.remote_file_list = MagicMock(GetItemCount=MagicMock(return_value=1))
+    frame.remote_path_bar = MagicMock()
+    frame._update_title = MagicMock()
+    frame._apply_sort = MagicMock()
+    frame._populate_file_list = MagicMock()
+    frame._get_visible_files = MagicMock(return_value=[])
+    frame._remote_files = []
+    frame.FindFocus = MagicMock(return_value=object())
+
+    files = [RemoteFile(name="f.txt", path="/home/user/f.txt")]
+    app.MainFrame._on_remote_files_loaded(frame, files, "/home/user")
+
+    frame.remote_file_list.SetFocus.assert_not_called()
+
+
+def test_on_remote_files_loaded_keeps_remote_focus_when_already_active(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+
+    from portkeydrop.protocols import RemoteFile
+
+    frame._client = MagicMock(cwd="/home/user")
+    frame._remote_filter_text = ""
+    frame._settings = MagicMock()
+    frame._settings.display.announce_file_count = False
+    frame.remote_file_list = MagicMock(GetItemCount=MagicMock(return_value=1))
+    frame.remote_path_bar = MagicMock()
+    frame._update_title = MagicMock()
+    frame._apply_sort = MagicMock()
+    frame._populate_file_list = MagicMock()
+    frame._get_visible_files = MagicMock(return_value=[])
+    frame._remote_files = []
+    frame.FindFocus = MagicMock(return_value=frame.remote_file_list)
+
+    files = [RemoteFile(name="f.txt", path="/home/user/f.txt")]
+    app.MainFrame._on_remote_files_loaded(frame, files, "/home/user")
+
+    frame.remote_file_list.SetFocus.assert_called_once()
+
+
 def test_on_remote_files_error_shows_messagebox(app_module):
     app, fake_wx = app_module
     frame = _hydrate_frame(app_module)
@@ -425,6 +538,56 @@ def test_on_remote_files_error_shows_messagebox(app_module):
     fake_wx.MessageBox.assert_called_once()
     args = fake_wx.MessageBox.call_args[0]
     assert "Permission denied" in args[0]
+
+
+def test_refresh_local_files_does_not_steal_focus(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+
+    from portkeydrop.protocols import RemoteFile
+
+    frame._local_cwd = "/tmp"
+    frame._local_filter_text = ""
+    frame._settings = MagicMock()
+    frame._settings.display.announce_file_count = False
+    frame.local_file_list = MagicMock(GetItemCount=MagicMock(return_value=1))
+    frame.local_path_bar = MagicMock()
+    frame._apply_sort = MagicMock()
+    frame._populate_file_list = MagicMock()
+    frame._get_visible_files = MagicMock(return_value=[MagicMock()])
+    frame.FindFocus = MagicMock(return_value=object())
+
+    with patch.object(
+        app, "list_local_dir", return_value=[RemoteFile(name="a.txt", path="/tmp/a.txt")]
+    ):
+        app.MainFrame._refresh_local_files(frame)
+
+    frame.local_file_list.SetFocus.assert_not_called()
+
+
+def test_refresh_local_files_keeps_focus_when_local_list_active(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+
+    from portkeydrop.protocols import RemoteFile
+
+    frame._local_cwd = "/tmp"
+    frame._local_filter_text = ""
+    frame._settings = MagicMock()
+    frame._settings.display.announce_file_count = False
+    frame.local_file_list = MagicMock(GetItemCount=MagicMock(return_value=1))
+    frame.local_path_bar = MagicMock()
+    frame._apply_sort = MagicMock()
+    frame._populate_file_list = MagicMock()
+    frame._get_visible_files = MagicMock(return_value=[MagicMock()])
+    frame.FindFocus = MagicMock(return_value=frame.local_file_list)
+
+    with patch.object(
+        app, "list_local_dir", return_value=[RemoteFile(name="a.txt", path="/tmp/a.txt")]
+    ):
+        app.MainFrame._refresh_local_files(frame)
+
+    frame.local_file_list.SetFocus.assert_called_once()
 
 
 def test_on_remote_files_error_timeout_message(app_module):

--- a/tests/test_host_key_dialog.py
+++ b/tests/test_host_key_dialog.py
@@ -33,6 +33,9 @@ class _Window:
     def SetMinSize(self, _size) -> None:
         pass
 
+    def SetName(self, name: str) -> None:
+        self.name = name
+
     def EndModal(self, result: int) -> None:
         self._modal_result = result
 
@@ -62,12 +65,22 @@ class _StaticText(_Window):
 
 
 class _Button(_Window):
-    def __init__(self, parent=None, label: str = "", **_kw):
+    def __init__(self, parent=None, label: str = "", id: int | None = None, **_kw):
         super().__init__(parent)
         self.label = label
+        self.id = id
+
+
+class _TextCtrl(_Window):
+    def __init__(self, parent=None, value: str = "", style: int = 0, size=None, **_kw):
+        super().__init__(parent)
+        self.value = value
+        self.style = style
+        self.size = size
 
 
 _EVT_BUTTON = object()
+_EVT_CHAR_HOOK = object()
 
 
 def _make_wx_modules():
@@ -85,9 +98,16 @@ def _make_wx_modules():
     fake_wx = types.ModuleType("wx")
     fake_wx.DEFAULT_DIALOG_STYLE = 1
     fake_wx.RESIZE_BORDER = 2
+    fake_wx.TE_MULTILINE = 4
+    fake_wx.TE_READONLY = 8
+    fake_wx.ID_NO = 5103
+    fake_wx.ID_CANCEL = 5101
+    fake_wx.WXK_ESCAPE = 27
     fake_wx.StaticText = _StaticText
+    fake_wx.TextCtrl = _TextCtrl
     fake_wx.Button = _Button
     fake_wx.EVT_BUTTON = _EVT_BUTTON
+    fake_wx.EVT_CHAR_HOOK = _EVT_CHAR_HOOK
     fake_wx.lib = fake_lib
 
     return fake_wx, fake_lib, fake_sc
@@ -126,24 +146,49 @@ class TestHostKeyDialogConstants:
 
 
 class TestHostKeyDialogInit:
-    def test_creates_host_label_with_hostname(self, monkeypatch):
-        """Line 23: StaticText displays the unknown hostname."""
+    def test_security_text_contains_hostname(self, monkeypatch):
         dlg_cls = _load_host_key_dialog(monkeypatch)
-        dlg_cls(None, "example.com", "ssh-rsa", "aa:bb:cc:dd")
-        labels = [s.label for s in _StaticText.created]
-        assert any("example.com" in lbl for lbl in labels)
+        dlg = dlg_cls(None, "example.com", "ssh-rsa", "aa:bb:cc:dd")
+        text = next(c for c in dlg._pane.children if isinstance(c, _TextCtrl))
+        assert "example.com" in text.value
 
-    def test_creates_key_type_label(self, monkeypatch):
+    def test_security_text_contains_key_type(self, monkeypatch):
         dlg_cls = _load_host_key_dialog(monkeypatch)
-        dlg_cls(None, "host.test", "ecdsa-sha2-nistp256", "ff:ee:dd")
-        labels = [s.label for s in _StaticText.created]
-        assert any("ecdsa-sha2-nistp256" in lbl for lbl in labels)
+        dlg = dlg_cls(None, "host.test", "ecdsa-sha2-nistp256", "ff:ee:dd")
+        text = next(c for c in dlg._pane.children if isinstance(c, _TextCtrl))
+        assert "ecdsa-sha2-nistp256" in text.value
 
-    def test_creates_fingerprint_label(self, monkeypatch):
+    def test_security_text_contains_fingerprint(self, monkeypatch):
         dlg_cls = _load_host_key_dialog(monkeypatch)
-        dlg_cls(None, "host.test", "ssh-ed25519", "de:ad:be:ef")
-        labels = [s.label for s in _StaticText.created]
-        assert any("de:ad:be:ef" in lbl for lbl in labels)
+        dlg = dlg_cls(None, "host.test", "ssh-ed25519", "de:ad:be:ef")
+        text = next(c for c in dlg._pane.children if isinstance(c, _TextCtrl))
+        assert "de:ad:be:ef" in text.value
+
+    def test_dialog_sets_accessible_name(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg = dlg_cls(None, "host.test", "ssh-ed25519", "de:ad:be:ef")
+        assert dlg.name == "Unknown Host Key"
+
+    def test_initial_focus_is_security_text(self, monkeypatch):
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg = dlg_cls(None, "host.test", "ssh-ed25519", "de:ad:be:ef")
+        text = next(c for c in dlg._pane.children if isinstance(c, _TextCtrl))
+        assert text._focused is True
+
+    def test_escape_rejects_dialog(self, monkeypatch):
+        from types import SimpleNamespace
+
+        dlg_cls = _load_host_key_dialog(monkeypatch)
+        dlg = dlg_cls(None, "host.test", "ssh-ed25519", "de:ad:be:ef")
+        event, handler = next(bound for bound in dlg._bound if bound[0] is _EVT_CHAR_HOOK)
+        _ = event
+
+        def skip():
+            return None
+
+        key_event = SimpleNamespace(GetKeyCode=lambda: 27, Skip=skip)
+        handler(key_event)
+        assert dlg._modal_result == dlg_cls.REJECT
 
     def test_accept_permanent_button_bind(self, monkeypatch):
         """Line 35: Accept Permanently button binds a handler."""


### PR DESCRIPTION
Closes #31
Closes #32
Closes #33
Closes #35

## Changes
- HostKeyDialog: consolidated security text, SetName, safe default focus, Escape→Reject
- Refresh methods: focus guard prevents stealing focus from active pane
- F6: switches focus between local and remote panes with announcement
- Ctrl+L: jumps focus to Host field in connection toolbar