### PR TITLE
fix(import): map source selection against detected client list

### DIFF
--- a/src/portkeydrop/dialogs/import_connections.py
+++ b/src/portkeydrop/dialogs/import_connections.py
@@ -165,21 +165,28 @@ class ImportConnectionsDialog(wx.Dialog):
         panel.SetSizer(sizer)
         return panel
 
+    def _selected_source_key(self) -> str:
+        """Return currently selected source key from available choices."""
+        index = self.source_radio.GetSelection()
+        if 0 <= index < len(self._available_sources):
+            return self._available_sources[index].key
+        return "from_file"
+
     def _on_source_change(self, event: wx.CommandEvent) -> None:
-        self._source = SOURCES[self.source_radio.GetSelection()].key
+        self._source = self._selected_source_key()
         self._run_autodetect()
 
     def _on_autodetect(self, event: wx.CommandEvent) -> None:
         self._run_autodetect()
 
     def _run_autodetect(self) -> None:
-        source = SOURCES[self.source_radio.GetSelection()].key
+        source = self._selected_source_key()
         default_path = detect_default_path(source)
         if default_path is not None:
             self.path_text.SetValue(str(default_path))
 
     def _on_browse_file(self, event: wx.CommandEvent) -> None:
-        source = SOURCES[self.source_radio.GetSelection()].key
+        source = self._selected_source_key()
         wildcard = self._file_wildcard_for_source(source)
         with wx.FileDialog(
             self,
@@ -244,7 +251,7 @@ class ImportConnectionsDialog(wx.Dialog):
         use_registry = input_path == WINSCP_REGISTRY_SENTINEL
         path = None if use_registry else (Path(input_path).expanduser() if input_path else None)
 
-        source = SOURCES[self.source_radio.GetSelection()].key
+        source = self._selected_source_key()
         if source == "from_file" and not path:
             wx.MessageBox(
                 "Choose a file or folder for 'From file...' import.",

--- a/tests/test_import_connections_dialog.py
+++ b/tests/test_import_connections_dialog.py
@@ -257,8 +257,17 @@ class TestWinSCPRegistrySentinel:
         from portkeydrop.importers import WINSCP_REGISTRY_SENTINEL
         from portkeydrop.importers.models import ImportedSite
 
-        dlg = DialogCls(None)
-        dlg.source_radio.SetSelection(1)  # WinSCP
+        from portkeydrop.importers import ImportSource
+
+        with patch(
+            "portkeydrop.dialogs.import_connections.available_sources",
+            return_value=[
+                ImportSource("winscp", "WinSCP"),
+                ImportSource("from_file", "From file..."),
+            ],
+        ):
+            dlg = DialogCls(None)
+        dlg.source_radio.SetSelection(0)  # WinSCP in filtered list
         dlg.path_text.SetValue(WINSCP_REGISTRY_SENTINEL)
 
         fake_site = ImportedSite(name="test", protocol="sftp", host="example.com", port=22)
@@ -270,3 +279,33 @@ class TestWinSCPRegistrySentinel:
 
         assert result is True
         mock_load.assert_called_once_with("winscp", None)
+
+
+class TestAvailableSourceIndexMapping:
+    """Selection index should map against available (filtered) source list."""
+
+    def test_autodetect_uses_filtered_source_list(self, monkeypatch):
+        """If only WinSCP + From file are available, index 0 must map to WinSCP."""
+        DialogCls = _load_dialog(monkeypatch)
+        from portkeydrop.importers import ImportSource
+
+        with patch(
+            "portkeydrop.dialogs.import_connections.available_sources",
+            return_value=[
+                ImportSource("winscp", "WinSCP"),
+                ImportSource("from_file", "From file..."),
+            ],
+        ):
+            dlg = DialogCls(None)
+
+        # First choice in filtered list is WinSCP, not FileZilla.
+        dlg.source_radio.SetSelection(0)
+
+        with patch(
+            "portkeydrop.dialogs.import_connections.detect_default_path",
+            return_value="/fake/WinSCP.ini",
+        ) as mock_detect:
+            dlg._on_autodetect(_CommandEvent())
+
+        mock_detect.assert_called_once_with("winscp")
+        assert dlg.path_text.GetValue() == "/fake/WinSCP.ini"


### PR DESCRIPTION
## Summary
- Fix Import Connections dialog source mapping to use filtered available_sources list
- Prevent wrong Auto-Detect path when only subset of clients is installed (for example WinSCP-only showing FileZilla path)
- Add regression test for filtered-source index mapping

## Repro
When FileZilla is not installed, source list can be WinSCP + From file. Selecting index 0 incorrectly mapped to static SOURCES[0] (FileZilla).

## Test Plan
- [x] uv run --no-sync pytest tests/test_import_connections_dialog.py -q
