### PR TITLE
fix(importers): correct WinSCP password decryption

### DIFF
--- a/src/portkeydrop/importers/winscp.py
+++ b/src/portkeydrop/importers/winscp.py
@@ -183,27 +183,26 @@ def _decrypt_winscp_password(username: str, hostname: str, encrypted: str) -> st
     Algorithm reference: https://github.com/NetSPI/WinSCPPasswordDecryptor
     """
     key = username + hostname
-    encrypted_bytes = [int(encrypted[i : i + 2], 16) for i in range(0, len(encrypted), 2)]
+    encrypted_hex = [encrypted[i : i + 2] for i in range(0, len(encrypted), 2)]
 
-    flag = _decrypt_next(encrypted_bytes)
-    if flag == _MAGIC:
-        _decrypt_next(encrypted_bytes)  # skip byte
-        length = _decrypt_next(encrypted_bytes)
+    flag = _decrypt_next(encrypted_hex)
+    if flag == 0xFF:
+        _decrypt_next(encrypted_hex)  # skip byte
+        length = _decrypt_next(encrypted_hex)
     else:
         length = flag
 
     result: list[str] = []
     for _ in range(length):
-        result.append(chr(_decrypt_next(encrypted_bytes) ^ _MAGIC))
+        result.append(chr(_decrypt_next(encrypted_hex)))
 
     password = "".join(result)
-    if flag == _MAGIC:
+    if flag == 0xFF:
         password = password[len(key) :]
     return password
 
 
-def _decrypt_next(encrypted_bytes: list[int]) -> int:
-    """Consume two values from the byte list and return one decrypted byte."""
-    a = encrypted_bytes.pop(0)
-    b = encrypted_bytes.pop(0)
-    return (((a << 4) + b) ^ _MAGIC) & 0xFF
+def _decrypt_next(encrypted_hex: list[str]) -> int:
+    """Consume one hex-encoded byte and return one decrypted byte."""
+    b = int(encrypted_hex.pop(0), 16)
+    return (~(b ^ _MAGIC)) & 0xFF

--- a/tests/test_importers_winscp.py
+++ b/tests/test_importers_winscp.py
@@ -22,15 +22,11 @@ def _encrypt_winscp_password(username: str, hostname: str, password: str) -> str
     data = key + password
 
     def enc(v: int) -> str:
-        """Encode header byte (flag, skip, length)."""
-        x = (v ^ _MAGIC) & 0xFF
-        return f"{(x >> 4):02x}{(x & 0xF):02x}"
+        """Encode one WinSCP-obfuscated byte as two hex chars."""
+        x = (~v & 0xFF) ^ _MAGIC
+        return f"{x:02X}"
 
-    def enc_data(v: int) -> str:
-        """Encode data character byte."""
-        return f"{(v >> 4):02x}{(v & 0xF):02x}"
-
-    return enc(_MAGIC) + enc(0) + enc(len(data)) + "".join(enc_data(ord(c)) for c in data)
+    return enc(0xFF) + enc(0) + enc(len(data)) + "".join(enc(ord(c)) for c in data)
 
 
 def test_parse_winscp_ini_fixture(tmp_path):


### PR DESCRIPTION
## Summary
- Fix WinSCP password decryption to consume one hex byte per step (correct WinSCP format)
- Use proper 0xFF flagged-header handling used by WinSCP exports
- Update test vector encoder in tests to match real WinSCP obfuscation

## Why
Real WinSCP imports were losing passwords even when  existed in INI/registry entries.

## Test Plan
- [x] uv run --no-sync pytest tests/test_importers_winscp.py -q
