### PR TITLE
fix(migration): remove Alt+Space mnemonic from sites checkbox label

### DIFF
--- a/src/portkeydrop/migration.py
+++ b/src/portkeydrop/migration.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 MIGRATION_ITEMS: list[tuple[str, str]] = [
-    ("Sites & connections", "sites.json"),
+    ("Sites and connections", "sites.json"),
     ("Saved passwords (encrypted vault)", "vault.enc"),
     ("Known SSH hosts", "known_hosts"),
     ("App settings", "settings.json"),


### PR DESCRIPTION
## Summary
- Change migration checkbox label from Sites & connections to Sites and connections
- Removes accidental mnemonic assignment on Space key in migration dialog

## Why
The ampersand in the label created unintended keyboard mnemonic behavior.

## Test
- [x] uv run --no-sync pytest tests/test_migration_dialog.py tests/test_app_migration_startup.py -q
