### PR TITLE
fix(a11y): improve accessible names for local and remote list views

### DIFF
--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -239,7 +239,7 @@ class MainFrame(wx.Frame):
         local_sizer.Add(self.local_path_bar, 0, wx.EXPAND | wx.ALL, 2)
 
         self.local_file_list = wx.ListCtrl(local_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.local_file_list.SetName("Local Files")
+        self.local_file_list.SetName("Local files list view")
         self.local_file_list.InsertColumn(0, "Name", width=200)
         self.local_file_list.InsertColumn(1, "Size", width=80)
         self.local_file_list.InsertColumn(2, "Type", width=70)
@@ -260,7 +260,7 @@ class MainFrame(wx.Frame):
         remote_sizer.Add(self.remote_path_bar, 0, wx.EXPAND | wx.ALL, 2)
 
         self.remote_file_list = wx.ListCtrl(remote_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.remote_file_list.SetName("Remote Files")
+        self.remote_file_list.SetName("Remote files list view")
         self.remote_file_list.InsertColumn(0, "Name", width=200)
         self.remote_file_list.InsertColumn(1, "Size", width=80)
         self.remote_file_list.InsertColumn(2, "Type", width=70)

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -240,8 +240,11 @@ class MainFrame(wx.Frame):
         self.local_path_bar.SetName("Local Path")
         local_sizer.Add(self.local_path_bar, 0, wx.EXPAND | wx.ALL, 2)
 
-        self.local_file_list = wx.ListCtrl(local_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.local_file_list.SetName("Local files list view")
+        self.local_file_list = wx.ListCtrl(
+            local_panel,
+            style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
+            name="Local files list view",
+        )
         self.local_file_list.InsertColumn(0, "Name", width=200)
         self.local_file_list.InsertColumn(1, "Size", width=80)
         self.local_file_list.InsertColumn(2, "Type", width=70)
@@ -261,8 +264,11 @@ class MainFrame(wx.Frame):
         self.remote_path_bar.SetName("Remote Path")
         remote_sizer.Add(self.remote_path_bar, 0, wx.EXPAND | wx.ALL, 2)
 
-        self.remote_file_list = wx.ListCtrl(remote_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.remote_file_list.SetName("Remote files list view")
+        self.remote_file_list = wx.ListCtrl(
+            remote_panel,
+            style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
+            name="Remote files list view",
+        )
         self.remote_file_list.InsertColumn(0, "Name", width=200)
         self.remote_file_list.InsertColumn(1, "Size", width=80)
         self.remote_file_list.InsertColumn(2, "Type", width=70)

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -243,7 +243,7 @@ class MainFrame(wx.Frame):
         self.local_file_list = wx.ListCtrl(
             local_panel,
             style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
-            name="Local files list view",
+            name="Local",
         )
         self.local_file_list.InsertColumn(0, "Name", width=200)
         self.local_file_list.InsertColumn(1, "Size", width=80)
@@ -267,7 +267,7 @@ class MainFrame(wx.Frame):
         self.remote_file_list = wx.ListCtrl(
             remote_panel,
             style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
-            name="Remote files list view",
+            name="Remote",
         )
         self.remote_file_list.InsertColumn(0, "Name", width=200)
         self.remote_file_list.InsertColumn(1, "Size", width=80)


### PR DESCRIPTION
## Summary
- Update list control accessible names to explicit phrases:
  - Local files list view
  - Remote files list view
- No behavior changes; naming-only accessibility improvement

## Why
Some screen readers currently announce only a generic control role for these panes.

## Test
- [x] uv run --no-sync ruff check src/portkeydrop/app.py
