### PR TITLE
fix(importers): decode URL-encoded WinSCP key paths

### DIFF
--- a/src/portkeydrop/importers/winscp.py
+++ b/src/portkeydrop/importers/winscp.py
@@ -56,7 +56,7 @@ def parse_ini_file(path: Path) -> list[ImportedSite]:
 
         username = cfg.get("UserName", "").strip()
         initial_dir = cfg.get("RemoteDirectory", "").strip() or "/"
-        key_path = cfg.get("PublicKeyFile", "").strip()
+        key_path = _decode_path(cfg.get("PublicKeyFile", "").strip())
         name = _decode_name(section.removeprefix("Sessions\\"))
         password = _safe_decrypt(cfg.get("Password", "").strip(), username, host)
 
@@ -113,7 +113,7 @@ def parse_registry_sessions() -> list[ImportedSite]:
 
                     username = values.get("UserName", "").strip()
                     initial_dir = values.get("RemoteDirectory", "").strip() or "/"
-                    key_path_value = values.get("PublicKeyFile", "").strip()
+                    key_path_value = _decode_path(values.get("PublicKeyFile", "").strip())
                     password = _safe_decrypt(values.get("Password", "").strip(), username, host)
 
                     sites.append(
@@ -164,6 +164,11 @@ def _detect_protocol(cfg: configparser.SectionProxy | dict[str, str]) -> str:
 
 def _decode_name(raw_name: str) -> str:
     return unquote(raw_name).replace("%5C", "\\")
+
+
+def _decode_path(raw_path: str) -> str:
+    """Decode WinSCP-encoded path values (e.g. C:%5CUsers%5C...)."""
+    return unquote(raw_path)
 
 
 def _safe_decrypt(encrypted: str, username: str, hostname: str) -> str:

--- a/tests/test_importers_winscp.py
+++ b/tests/test_importers_winscp.py
@@ -243,3 +243,19 @@ def test_parse_ini_missing_password_field(tmp_path):
     ini = tmp_path / "w.ini"
     ini.write_text("[Sessions\\H]\nHostName=h.com\nPortNumber=22\nUserName=u\n")
     assert parse_ini_file(ini)[0].password == ""
+
+
+def test_parse_ini_decodes_urlencoded_public_key_path(tmp_path):
+    ini = tmp_path / "winscp.ini"
+    ini.write_text(
+        """
+[Sessions\\EncodedKey]
+HostName=example.com
+UserName=test
+PublicKeyFile=C:%5CUsers%5Cstick%5CDocuments%5Ckey.ppk
+""".strip(),
+        encoding="utf-8",
+    )
+
+    site = parse_ini_file(ini)[0]
+    assert site.key_path == r"C:\Users\stick\Documents\key.ppk"


### PR DESCRIPTION
## Summary
- Decode WinSCP PublicKeyFile values when importing from INI/registry
- Fixes URL-encoded key paths (e.g. `C:%5CUsers%5C...%5Ckey.ppk`) becoming unusable
- Adds regression test for URL-encoded key path input

## Why
WinSCP stores some path fields URL-encoded. Without decoding, Portkey Drop cannot locate the user’s PPK file after import.

## Test
- [x] uv run --no-sync pytest tests/test_importers_winscp.py -q
