### PR TITLE
fix(importers): prevent malformed/truncated WinSCP password imports

### DIFF
--- a/src/portkeydrop/importers/winscp.py
+++ b/src/portkeydrop/importers/winscp.py
@@ -192,13 +192,20 @@ def _decrypt_winscp_password(username: str, hostname: str, encrypted: str) -> st
     else:
         length = flag
 
+    offset = _decrypt_next(encrypted_hex)
+    for _ in range(offset):
+        _decrypt_next(encrypted_hex)
+
     result: list[str] = []
     for _ in range(length):
         result.append(chr(_decrypt_next(encrypted_hex)))
 
     password = "".join(result)
     if flag == 0xFF:
-        password = password[len(key) :]
+        if password.startswith(key):
+            password = password[len(key) :]
+        elif key:
+            raise ValueError("Unable to validate WinSCP key prefix")
     return password
 
 

--- a/tests/test_importers_winscp.py
+++ b/tests/test_importers_winscp.py
@@ -16,7 +16,9 @@ from portkeydrop.importers.winscp import (
 _MAGIC = 0xA3  # Same magic as production code
 
 
-def _encrypt_winscp_password(username: str, hostname: str, password: str) -> str:
+def _encrypt_winscp_password(
+    username: str, hostname: str, password: str, *, offset: int = 0
+) -> str:
     """Inverse of _decrypt_winscp_password - used to generate test vectors."""
     key = username + hostname
     data = key + password
@@ -26,7 +28,10 @@ def _encrypt_winscp_password(username: str, hostname: str, password: str) -> str
         x = (~v & 0xFF) ^ _MAGIC
         return f"{x:02X}"
 
-    return enc(0xFF) + enc(0) + enc(len(data)) + "".join(enc(ord(c)) for c in data)
+    filler = "".join(enc(0) for _ in range(offset))
+    return enc(0xFF) + enc(0) + enc(len(data)) + enc(offset) + filler + "".join(
+        enc(ord(c)) for c in data
+    )
 
 
 def test_parse_winscp_ini_fixture(tmp_path):
@@ -221,6 +226,16 @@ def test_decrypt_winscp_password_known_value():
 def test_decrypt_winscp_password_different_credentials():
     encrypted = _encrypt_winscp_password("user", "host.test", "mypassword")
     assert _decrypt_winscp_password("user", "host.test", encrypted) == "mypassword"
+
+
+def test_decrypt_winscp_password_with_offset_padding():
+    encrypted = _encrypt_winscp_password("user", "host.test", "mypassword", offset=3)
+    assert _decrypt_winscp_password("user", "host.test", encrypted) == "mypassword"
+
+
+def test_safe_decrypt_wrong_key_prefix_returns_empty():
+    encrypted = _encrypt_winscp_password("user", "host.test", "mypassword")
+    assert _safe_decrypt(encrypted, "other", "host.test") == ""
 
 
 def test_safe_decrypt_empty_password():


### PR DESCRIPTION
## Summary
- handle WinSCP encrypted password offset/padding bytes during decryption
- reject keyed payloads when the decrypted prefix cannot be validated, returning an empty password via the existing safe wrapper
- add tests for offset/padding decryption and key-prefix mismatch fallback

## Root Cause
The importer was reading WinSCP payload bytes immediately after the length header and ignored the encoded offset/padding segment used by some session formats. That misaligned reads and produced malformed/truncated decrypted values. It also always removed the username+hostname-length prefix from flagged payloads even when the prefix did not match, which could truncate wrong decrypt results.

## Test Plan
- uv run --no-sync pytest tests/test_importers_winscp.py tests/test_importers_init.py -q

Fixes #70