### PR TITLE
fix(importers): prevent malformed/truncated WinSCP password imports

### DIFF
--- a/installer/build.py
+++ b/installer/build.py
@@ -469,9 +469,8 @@ def generate_build_metadata(args: argparse.Namespace) -> None:
 
 def _in_virtual_environment() -> bool:
     """Return True when running inside an activated Python virtual environment."""
-    return (
-        sys.prefix != getattr(sys, "base_prefix", sys.prefix)
-        or bool(os.environ.get("VIRTUAL_ENV"))
+    return sys.prefix != getattr(sys, "base_prefix", sys.prefix) or bool(
+        os.environ.get("VIRTUAL_ENV")
     )
 
 

--- a/src/portkeydrop/importers/winscp.py
+++ b/src/portkeydrop/importers/winscp.py
@@ -183,6 +183,8 @@ def _decrypt_winscp_password(username: str, hostname: str, encrypted: str) -> st
     Algorithm reference: https://github.com/NetSPI/WinSCPPasswordDecryptor
     """
     key = username + hostname
+    if len(encrypted) % 2 != 0:
+        raise ValueError("Encrypted WinSCP password must have an even-length hex payload")
     encrypted_hex = [encrypted[i : i + 2] for i in range(0, len(encrypted), 2)]
 
     flag = _decrypt_next(encrypted_hex)
@@ -198,6 +200,8 @@ def _decrypt_winscp_password(username: str, hostname: str, encrypted: str) -> st
 
     password = "".join(result)
     if flag == 0xFF:
+        if not password.startswith(key):
+            raise ValueError("Decrypted WinSCP password does not match expected key prefix")
         password = password[len(key) :]
     return password
 

--- a/tests/test_importers_winscp.py
+++ b/tests/test_importers_winscp.py
@@ -29,6 +29,17 @@ def _encrypt_winscp_password(username: str, hostname: str, password: str) -> str
     return enc(0xFF) + enc(0) + enc(len(data)) + "".join(enc(ord(c)) for c in data)
 
 
+def _encrypt_winscp_payload(prefix: str, password: str) -> str:
+    """Build encrypted payload with custom key-prefix material."""
+    data = prefix + password
+
+    def enc(v: int) -> str:
+        x = (~v & 0xFF) ^ _MAGIC
+        return f"{x:02X}"
+
+    return enc(0xFF) + enc(0) + enc(len(data)) + "".join(enc(ord(c)) for c in data)
+
+
 def test_parse_winscp_ini_fixture(tmp_path):
     """Parse a WinSCP INI file with encrypted passwords."""
     # Generate encrypted passwords at test time (no hardcoded hex)
@@ -236,6 +247,17 @@ def test_safe_decrypt_invalid_hex():
 def test_safe_decrypt_truncated():
     """Truncated encrypted data returns empty password instead of crashing."""
     assert _safe_decrypt("0000", "alice", "host.com") == ""
+
+
+def test_safe_decrypt_key_prefix_mismatch_returns_empty():
+    """Mismatched key-prefix payload is treated as untrusted and discarded."""
+    encrypted = _encrypt_winscp_payload("host.test", "mypassword")
+    assert _safe_decrypt(encrypted, "user", "host.test") == ""
+
+
+def test_safe_decrypt_odd_length_hex_returns_empty():
+    """Odd-length hex payload is malformed and returns empty."""
+    assert _safe_decrypt("ABC", "alice", "host.com") == ""
 
 
 def test_parse_ini_missing_password_field(tmp_path):


### PR DESCRIPTION
## Summary
This change makes WinSCP password import fail closed when decrypted payloads cannot be trusted.

Root cause:
- `_decrypt_winscp_password` accepted any well-formed hex payload and always stripped `len(username + hostname)` characters when `flag == 0xFF`.
- If decrypted payload key material did not exactly match that expected prefix length, the importer could return truncated or mangled password fragments instead of failing.

## Changes
- Reject odd-length encrypted hex input early.
- For `flag == 0xFF`, require decrypted payload to start with the expected `username + hostname` prefix.
- Raise on prefix mismatch so `_safe_decrypt` returns an empty password.
- Add regression tests for:
  - key-prefix mismatch returning empty instead of truncated value
  - odd-length malformed hex returning empty

## Testing
- `PYTHONPATH=src pytest -q tests/test_importers_winscp.py`

Fixes #70
