### PR TITLE
fix(ci): isolate WordPress workflow from nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ env:
   PYTHON_VERSION: "3.11"
 
 jobs:
+  # WordPress sync is intentionally isolated in update-wordpress.yml to keep
+  # nightly build/release runs independent from external reusable workflow refs.
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
@@ -214,11 +216,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run update-pages.yml || true
-
-  push-to-wordpress:
-    needs: release
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
-    uses: Orinks/orinks-github-releases/.github/workflows/push-releases.yml@master
-    secrets:
-      WP_PUSH_TOKEN: ${{ secrets.WP_PUSH_TOKEN }}
-      WP_SITE_URL: ${{ secrets.WP_SITE_URL }}

--- a/.github/workflows/update-wordpress.yml
+++ b/.github/workflows/update-wordpress.yml
@@ -1,0 +1,15 @@
+name: Update WordPress on release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  push-to-wordpress:
+    # Keep WordPress sync isolated from build.yml so nightly build/release stays green
+    # even if this external reusable workflow changes or WordPress push fails.
+    uses: Orinks/orinks-github-releases/.github/workflows/push-releases.yml@33718ad2cfa0be8370963fe150abc1de0b7c922b
+    secrets:
+      WP_PUSH_TOKEN: ${{ secrets.WP_PUSH_TOKEN }}
+      WP_SITE_URL: ${{ secrets.WP_SITE_URL }}


### PR DESCRIPTION
## Summary
- remove the external reusable WordPress job from `.github/workflows/build.yml`
- add a dedicated `.github/workflows/update-wordpress.yml` triggered by `release.published`
- pin external reusable workflow ref to commit `33718ad2cfa0be8370963fe150abc1de0b7c922b` (no branch refs)
- document why WordPress sync is isolated so nightly schedule cannot fail from reusable workflow resolution

## Diagnosis
- scheduled run `22654788122` on `main` failed with **zero jobs** and GitHub marked it as a workflow-file issue
- `build.yml` on default branch referenced `Orinks/orinks-github-releases/.github/workflows/push-releases.yml@master`
- that makes nightly parsing dependent on a mutable external ref, so ref/branch/workflow changes can break schedule before jobs start

## Validation
- `actionlint` run locally against workflows (pass)
