### PR TITLE
feat(importers): map FileZilla keyfile to key_path

### DIFF
--- a/src/portkeydrop/importers/filezilla.py
+++ b/src/portkeydrop/importers/filezilla.py
@@ -6,6 +6,7 @@ import base64
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from .models import ImportedSite
 
@@ -46,6 +47,7 @@ def _parse_root(root: ET.Element) -> list[ImportedSite]:
 
         username = (server.findtext("User") or "").strip()
         password = _decode_password(server)
+        key_path = _parse_key_path(server, protocol)
 
         raw_remote_dir = (server.findtext("RemoteDir") or "").strip()
         initial_dir = _parse_remote_dir(raw_remote_dir)
@@ -61,6 +63,7 @@ def _parse_root(root: ET.Element) -> list[ImportedSite]:
                 port=port,
                 username=username,
                 password=password,
+                key_path=key_path,
                 initial_dir=initial_dir,
                 notes=notes,
             )
@@ -81,6 +84,45 @@ def _decode_password(server: ET.Element) -> str:
         except Exception:
             return ""
     return raw_password
+
+
+def _parse_key_path(server: ET.Element, protocol: str) -> str:
+    if protocol != "sftp":
+        return ""
+
+    raw_key_path = ""
+    key_element = server.find("Keyfile")
+    if key_element is not None and key_element.text:
+        raw_key_path = key_element.text
+    else:
+        # Some exports/custom XML variants use KeyFile casing.
+        key_element = server.find("KeyFile")
+        if key_element is not None and key_element.text:
+            raw_key_path = key_element.text
+
+    raw_key_path = raw_key_path.strip()
+    if not raw_key_path:
+        return ""
+    return _normalize_key_path(raw_key_path)
+
+
+def _normalize_key_path(raw_key_path: str) -> str:
+    parsed = urlparse(raw_key_path)
+    if parsed.scheme.lower() != "file":
+        return raw_key_path
+
+    decoded_path = unquote(parsed.path or "")
+    if parsed.netloc:
+        unc_tail = decoded_path.lstrip("/").replace("/", "\\")
+        return f"\\\\{parsed.netloc}\\{unc_tail}" if unc_tail else f"\\\\{parsed.netloc}"
+
+    # file:///C:/... => C:\...
+    if len(decoded_path) >= 3 and decoded_path[0] == "/" and decoded_path[2] == ":":
+        return decoded_path[1:].replace("/", "\\")
+
+    if decoded_path:
+        return decoded_path
+    return raw_key_path
 
 
 def _parse_remote_dir(raw_remote_dir: str) -> str:

--- a/tests/fixtures/importers/filezilla_sitemanager.xml
+++ b/tests/fixtures/importers/filezilla_sitemanager.xml
@@ -8,6 +8,7 @@
       <Protocol>1</Protocol>
       <User>alice</User>
       <Pass encoding="base64">c2VjcmV0</Pass>
+      <Keyfile>/home/alice/.ssh/id_ed25519</Keyfile>
       <RemoteDir>1 0 4 home 5 alice</RemoteDir>
       <Comments>Main production host</Comments>
     </Server>

--- a/tests/test_importers_filezilla.py
+++ b/tests/test_importers_filezilla.py
@@ -16,12 +16,14 @@ def test_parse_filezilla_sites_fixture():
     assert first.port == 2222
     assert first.username == "alice"
     assert first.password == "secret"
+    assert first.key_path == "/home/alice/.ssh/id_ed25519"
     assert first.initial_dir == "/home/alice"
     assert first.notes == "Main production host"
 
     second = sites[1]
     assert second.protocol == "ftp"
     assert second.password == "plaintext"
+    assert second.key_path == ""
     assert second.initial_dir == "/incoming"
 
 
@@ -64,6 +66,42 @@ def test_parse_file_invalid_port(tmp_path):
     f = tmp_path / "sm.xml"
     f.write_text(xml)
     assert parse_file(f)[0].port == 0
+
+
+def test_parse_file_keyfile_casing_variant(tmp_path):
+    from portkeydrop.importers.filezilla import parse_file
+
+    xml = '<?xml version="1.0"?><FileZilla3><Servers><Server><Host>sftp.example.com</Host><Protocol>1</Protocol><Port>22</Port><User>u</User><Pass></Pass><KeyFile>/tmp/id_rsa</KeyFile><RemoteDir>/</RemoteDir><Name>X</Name></Server></Servers></FileZilla3>'
+    f = tmp_path / "sm.xml"
+    f.write_text(xml)
+    assert parse_file(f)[0].key_path == "/tmp/id_rsa"
+
+
+def test_parse_file_keyfile_file_url_windows_drive(tmp_path):
+    from portkeydrop.importers.filezilla import parse_file
+
+    xml = '<?xml version="1.0"?><FileZilla3><Servers><Server><Host>sftp.example.com</Host><Protocol>1</Protocol><Port>22</Port><User>u</User><Pass></Pass><Keyfile>file:///C:/Users/Alice/.ssh/id_ed25519%20prod.ppk</Keyfile><RemoteDir>/</RemoteDir><Name>X</Name></Server></Servers></FileZilla3>'
+    f = tmp_path / "sm.xml"
+    f.write_text(xml)
+    assert parse_file(f)[0].key_path == "C:\\Users\\Alice\\.ssh\\id_ed25519 prod.ppk"
+
+
+def test_parse_file_keyfile_file_url_unc(tmp_path):
+    from portkeydrop.importers.filezilla import parse_file
+
+    xml = '<?xml version="1.0"?><FileZilla3><Servers><Server><Host>sftp.example.com</Host><Protocol>1</Protocol><Port>22</Port><User>u</User><Pass></Pass><Keyfile>file://fileserver/keys/id_ed25519.ppk</Keyfile><RemoteDir>/</RemoteDir><Name>X</Name></Server></Servers></FileZilla3>'
+    f = tmp_path / "sm.xml"
+    f.write_text(xml)
+    assert parse_file(f)[0].key_path == "\\\\fileserver\\keys\\id_ed25519.ppk"
+
+
+def test_parse_file_keyfile_not_mapped_for_non_sftp(tmp_path):
+    from portkeydrop.importers.filezilla import parse_file
+
+    xml = '<?xml version="1.0"?><FileZilla3><Servers><Server><Host>ftp.example.com</Host><Protocol>0</Protocol><Port>21</Port><User>u</User><Pass></Pass><Keyfile>/should/not/import</Keyfile><RemoteDir>/incoming</RemoteDir><Name>X</Name></Server></Servers></FileZilla3>'
+    f = tmp_path / "sm.xml"
+    f.write_text(xml)
+    assert parse_file(f)[0].key_path == ""
 
 
 def test_decode_password_base64_invalid():


### PR DESCRIPTION
## Summary
- Map FileZilla SSH key file entries into `ImportedSite.key_path` in the FileZilla importer.
- Parse FileZilla key-file field variants used in SFTP profiles:
  - `<Keyfile>` (confirmed in FileZilla source serialization/parser)
  - `<KeyFile>` (casing variant handling for robust imports)
- Normalize `file://` key paths to usable local paths:
  - `file:///C:/...` -> `C:\...`
  - `file://server/share/...` -> `\\server\share\...`
  - Percent-decoded paths are supported.
- Keep non-SFTP behavior unchanged (key path remains empty for FTP/FTPS).

## Scope guard
This PR is intentionally limited to FileZilla key-path mapping in importer parsing + tests.

## Validation
- `PYTHONPATH=src pytest -q tests/test_importers_filezilla.py tests/test_importers_init.py`
- `PYTHONPATH=src ruff check src/portkeydrop/importers/filezilla.py tests/test_importers_filezilla.py`

## Notes on schema inspection
Verified from FileZilla source mirror (`src/interface/xmlfunctions.cpp`) that Site Manager read/write uses `Keyfile` for credentials key file handling.
