### PR TITLE
fix(a11y): add cancel close button to SiteManagerDialog

### DIFF
--- a/src/portkeydrop/dialogs/site_manager.py
+++ b/src/portkeydrop/dialogs/site_manager.py
@@ -91,8 +91,12 @@ class SiteManagerDialog(wx.Dialog):
 
         right_sizer.Add(grid, 1, wx.EXPAND | wx.ALL, 4)
 
+        action_sizer = wx.BoxSizer(wx.HORIZONTAL)
         save_btn = wx.Button(self, label="&Save")
-        right_sizer.Add(save_btn, 0, wx.ALL | wx.ALIGN_RIGHT, 4)
+        self.close_btn = wx.Button(self, id=wx.ID_CANCEL, label="&Close")
+        action_sizer.Add(save_btn, 0, wx.RIGHT, 4)
+        action_sizer.Add(self.close_btn, 0)
+        right_sizer.Add(action_sizer, 0, wx.ALL | wx.ALIGN_RIGHT, 4)
 
         main_sizer.Add(right_sizer, 2, wx.EXPAND | wx.ALL, 4)
 

--- a/tests/test_site_manager_dialog.py
+++ b/tests/test_site_manager_dialog.py
@@ -127,7 +127,8 @@ class _TextCtrl(_Window):
 
 
 class _Button(_Window):
-    def __init__(self, parent=None, label="", **_kw):
+    def __init__(self, parent=None, id=None, label="", **_kw):
+        self._id = id
         self._label = label
         self._name = ""
 
@@ -136,6 +137,9 @@ class _Button(_Window):
 
     def SetName(self, v):
         self._name = v
+
+    def GetId(self):
+        return self._id
 
 
 class _Choice(_Window):
@@ -351,6 +355,19 @@ class TestSiteManagerDialogInit:
         assert dlg.show_password_btn._label == "S&how"
         assert dlg.show_password_btn._name == "Show password"
         assert hasattr(dlg, "password_text")
+
+    def test_init_creates_close_button_with_cancel_id(self, dialog_module):
+        from portkeydrop.sites import SiteManager
+
+        mod, fake_wx = dialog_module
+        site_manager = MagicMock(spec=SiteManager)
+        site_manager.sites = []
+
+        dlg = mod.SiteManagerDialog(None, site_manager)
+
+        assert hasattr(dlg, "close_btn")
+        assert dlg.close_btn._label == "&Close"
+        assert dlg.close_btn.GetId() == fake_wx.ID_CANCEL
 
 
 class TestEscapeKeyHandler:


### PR DESCRIPTION
## Summary
- add a dedicated Close button to SiteManagerDialog with id wx.ID_CANCEL
- keep existing Escape key handling (EVT_CHAR_HOOK) for keyboard dismissal
- extend dialog tests to verify close button exists and uses wx.ID_CANCEL

## Testing
- ruff check src/portkeydrop/dialogs/site_manager.py tests/test_site_manager_dialog.py
- python -m pytest tests/test_site_manager_dialog.py -q
- python -m pytest -q

Closes #34