### PR TITLE
fix(sftp): classify key import errors instead of passphrase false-positive

### DIFF
--- a/src/portkeydrop/protocols.py
+++ b/src/portkeydrop/protocols.py
@@ -483,11 +483,10 @@ class SFTPClient(TransferClient):
                 "Verify the server host key or adjust host key policy."
             ) from e
         except asyncssh.KeyImportError as e:
-            logger.error("Private key requires passphrase: %s", e)
-            raise ConnectionError(
-                "SFTP connection failed: the private key requires a passphrase. "
-                "Decrypt the key or use an agent/password."
-            ) from e
+            error_text = str(e)
+            key_import_message = self._format_key_import_error(error_text)
+            logger.error("Failed to import private key: %s", e)
+            raise ConnectionError(f"SFTP connection failed: {key_import_message}") from e
         except asyncssh.PermissionDenied as e:
             logger.error(
                 "SFTP authentication failed for %s. Methods attempted: %s",
@@ -550,6 +549,21 @@ class SFTPClient(TransferClient):
         except Exception as e:
             logger.error("Unexpected SFTP connection failure: %s", e)
             raise ConnectionError(f"SFTP connection failed: {e}") from e
+
+    @staticmethod
+    def _format_key_import_error(error_text: str) -> str:
+        text = error_text.lower()
+        if any(token in text for token in ("passphrase", "encrypted", "decrypt")):
+            return (
+                "the private key requires a passphrase. "
+                "Provide the key passphrase or use an SSH agent/password."
+            )
+        if any(token in text for token in ("invalid", "unsupported", "format", "malformed")):
+            return (
+                "the private key format is invalid or unsupported. "
+                "Use a valid OpenSSH/PKCS#8/PPK key file."
+            )
+        return "could not import the private key. Verify the key file, passphrase, and key format."
 
     def disconnect(self) -> None:
         if self._sftp:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -368,6 +368,48 @@ class TestSFTPClient:
             client.connect()
         assert not client.connected
 
+    @patch("os.path.exists", return_value=True)
+    @patch("asyncssh.connect", new_callable=AsyncMock)
+    def test_connect_key_import_error_requires_passphrase(self, mock_connect, _mock_exists):
+        import asyncssh
+
+        mock_connect.side_effect = asyncssh.KeyImportError(
+            "Key is encrypted and requires passphrase"
+        )
+        info = ConnectionInfo(
+            protocol=Protocol.SFTP,
+            host="example.com",
+            username="user",
+            key_path="/tmp/id_rsa",
+        )
+        client = SFTPClient(info)
+
+        with pytest.raises(ConnectionError) as exc:
+            client.connect()
+
+        assert "requires a passphrase" in str(exc.value)
+        assert "Provide the key passphrase" in str(exc.value)
+
+    @patch("os.path.exists", return_value=True)
+    @patch("asyncssh.connect", new_callable=AsyncMock)
+    def test_connect_key_import_error_invalid_format(self, mock_connect, _mock_exists):
+        import asyncssh
+
+        mock_connect.side_effect = asyncssh.KeyImportError("Invalid private key format")
+        info = ConnectionInfo(
+            protocol=Protocol.SFTP,
+            host="example.com",
+            username="user",
+            key_path="/tmp/bad_key",
+        )
+        client = SFTPClient(info)
+
+        with pytest.raises(ConnectionError) as exc:
+            client.connect()
+
+        assert "invalid or unsupported" in str(exc.value)
+        assert "OpenSSH/PKCS#8/PPK" in str(exc.value)
+
     @patch("asyncssh.connect", new_callable=AsyncMock)
     def test_disconnect(self, mock_connect):
         mock_conn = AsyncMock()


### PR DESCRIPTION
## Summary
- improve SFTP asyncssh.KeyImportError handling to distinguish passphrase-required vs invalid/unsupported key format vs generic key import failures
- preserve actionable user-facing connection error messages for each branch
- add focused protocol tests covering passphrase-required and invalid-format key import failures

## Testing
- pytest -q tests/test_protocols.py -k "key_import_error"
- pytest -q tests/test_protocols.py -k "test_connect_with_key_and_stat or test_connect_success or test_connect_failure or key_import_error"