### PR TITLE
fix(a11y): announce transfer cancellation clearly

### DIFF
--- a/src/portkeydrop/dialogs/transfer.py
+++ b/src/portkeydrop/dialogs/transfer.py
@@ -452,8 +452,21 @@ def create_transfer_dialog(parent, transfer_manager: TransferManager):
                     transfer.local_path
                 )
                 parent = self.GetParent()
-                if parent and hasattr(parent, "_announce") and filename:
-                    parent._announce(f"Cancelled transfer: {filename}")
+                status_message = (
+                    f"Transfer cancelled: {filename}" if filename else "Transfer cancelled."
+                )
+                announce = getattr(parent, "_announce", None) if parent else None
+                if callable(announce):
+                    announce(status_message)
+                update_status = getattr(parent, "_update_status", None) if parent else None
+                if callable(update_status):
+                    current_path = ""
+                    client = getattr(parent, "_client", None)
+                    if client is not None and bool(getattr(client, "connected", False)):
+                        cwd = getattr(client, "cwd", "")
+                        if isinstance(cwd, str):
+                            current_path = cwd
+                    update_status(status_message, current_path)
                 self._refresh()
 
         def _refresh(self):

--- a/tests/test_transfer_dialog.py
+++ b/tests/test_transfer_dialog.py
@@ -106,7 +106,70 @@ def test_cancel_announces_filename_before_refresh(transfer_module):
     dialog._on_cancel(None)
 
     manager.cancel.assert_called_once_with(5)
-    parent._announce.assert_called_once_with("Cancelled transfer: report.csv")
+    parent._announce.assert_called_once_with("Transfer cancelled: report.csv")
+    parent._update_status.assert_called_once_with("Transfer cancelled: report.csv", "")
+    dialog._refresh.assert_called_once()
+
+
+def test_cancel_announces_generic_message_when_filename_missing(transfer_module):
+    module, fake_wx = transfer_module
+    fake_wx.DEFAULT_DIALOG_STYLE = 0
+    fake_wx.RESIZE_BORDER = 0
+    fake_wx.CLOSE_BOX = 0
+    fake_wx.ID_CLOSE = 999
+    fake_wx.RIGHT = 0
+    fake_wx.ALIGN_RIGHT = 0
+    fake_wx.WXK_ESCAPE = 27
+    fake_wx.VERTICAL = 0
+    fake_wx.HORIZONTAL = 0
+
+    class _Dialog:
+        def __init__(self, parent, *args, **kwargs):
+            self._parent = parent
+
+        def Bind(self, *args, **kwargs):
+            return None
+
+        def SetSizer(self, *args, **kwargs):
+            return None
+
+        def SetName(self, *args, **kwargs):
+            return None
+
+        def Close(self):
+            return None
+
+        def GetParent(self):
+            return self._parent
+
+        def Destroy(self):
+            return None
+
+    fake_wx.Dialog = _Dialog
+
+    parent = MagicMock()
+    manager = MagicMock()
+    manager.transfers = [
+        SimpleNamespace(
+            id=7,
+            remote_path="/",
+            local_path="/",
+            direction=SimpleNamespace(value="download"),
+            progress_pct=0,
+            display_status="queued",
+        )
+    ]
+
+    dialog = module.create_transfer_dialog(parent, manager)
+    dialog.GetParent = MagicMock(return_value=parent)
+    dialog.transfer_list.GetFirstSelected.return_value = 0
+    dialog._refresh = MagicMock()
+
+    dialog._on_cancel(None)
+
+    manager.cancel.assert_called_once_with(7)
+    parent._announce.assert_called_once_with("Transfer cancelled.")
+    parent._update_status.assert_called_once_with("Transfer cancelled.", "")
     dialog._refresh.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- route transfer cancel confirmation through the existing `_announce` accessibility path with clearer wording
- also update the parent status label text immediately after cancel for instant feedback
- add coverage for both filename and filename-missing cancel confirmation messages

## Testing
- `ruff check .`
- `PYTHONPATH=src uv run --no-project --with pytest --with asyncssh --with keyring pytest -q`

Closes #40
