### PR TITLE
feat: add Updates tab to settings dialog

### DIFF
--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -51,6 +51,7 @@ class SettingsDialog(wx.Dialog):
         self._build_transfer_tab()
         self._build_display_tab()
         self._build_connection_tab()
+        self._build_updates_tab()
         self._build_speech_tab()
 
         root.Add(self.notebook, 1, wx.EXPAND | wx.ALL, 8)
@@ -350,6 +351,12 @@ class SettingsDialog(wx.Dialog):
             name="Remember last local folder on startup",
         )
 
+        sizer.AddStretchSpacer(1)
+        self.notebook.AddPage(panel, "Connection")
+
+    def _build_updates_tab(self) -> None:
+        panel, sizer = self._new_tab_panel()
+
         self.auto_update_check = self._add_checkbox_row(
             sizer,
             wx.CheckBox(panel, label="Check for updates &automatically"),
@@ -383,7 +390,7 @@ class SettingsDialog(wx.Dialog):
         self.check_updates_button.Bind(wx.EVT_BUTTON, self._on_check_updates_now)
 
         sizer.AddStretchSpacer(1)
-        self.notebook.AddPage(panel, "Connection")
+        self.notebook.AddPage(panel, "Updates")
 
     def _build_speech_tab(self) -> None:
         panel, sizer = self._new_tab_panel()

--- a/tests/test_settings_dialog_a11y.py
+++ b/tests/test_settings_dialog_a11y.py
@@ -334,6 +334,17 @@ def test_notebook_receives_initial_focus(monkeypatch):
     assert dlg.notebook.focused is True
 
 
+def test_notebook_includes_dedicated_updates_tab(monkeypatch):
+    dlg = _load_dialog(monkeypatch)
+    assert [title for _panel, title in dlg.notebook.pages] == [
+        "Transfer",
+        "Display",
+        "Connection",
+        "Updates",
+        "Speech",
+    ]
+
+
 def test_check_updates_button_invokes_callback_with_selected_channel(monkeypatch):
     calls: list[tuple[str, object]] = []
 


### PR DESCRIPTION
## Summary
- add a dedicated **Updates** tab in Settings
- move updater controls out of the Connection tab into Updates
- preserve existing app setting keys/behavior and manual-check callback wiring
- add a11y test coverage for notebook tab expectations including the new Updates tab

## Testing
- pytest -q tests/test_settings_dialog_a11y.py tests/test_app.py -k "settings or update"
- ruff check src tests