### PR TITLE
fix(a11y): evaluate DataViewListCtrl for local/remote panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Replaced local/remote file panes with `wx.dataview.DataViewListCtrl` to improve accessibility semantics while preserving dual-pane keyboard workflows and file operations.
+
 ---
 
 ## [0.1.0] - 2026-02-25

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -8,9 +8,11 @@ import sys
 import tempfile
 import threading
 from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 from pathlib import Path, PurePosixPath
 
 import wx
+import wx.dataview as dv
 
 from portkeydrop import __version__
 from portkeydrop.dialogs.properties import PropertiesDialog
@@ -86,6 +88,12 @@ ID_CHECK_UPDATES = wx.NewIdRef()
 ID_IMPORT_CONNECTIONS = wx.NewIdRef()
 ID_SWITCH_PANE_FOCUS = wx.NewIdRef()
 ID_FOCUS_ADDRESS_BAR = wx.NewIdRef()
+
+
+if TYPE_CHECKING:
+    FileListCtrl = wx.ListCtrl | dv.DataViewListCtrl
+else:
+    FileListCtrl = Any
 
 
 class MainFrame(wx.Frame):
@@ -277,13 +285,7 @@ class MainFrame(wx.Frame):
         self.local_path_bar.SetName("Local Path")
         local_sizer.Add(self.local_path_bar, 0, wx.EXPAND | wx.ALL, 2)
 
-        self.local_file_list = wx.ListCtrl(local_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.local_file_list.SetName("Local")
-        self.local_file_list.InsertColumn(0, "Name", width=200)
-        self.local_file_list.InsertColumn(1, "Size", width=80)
-        self.local_file_list.InsertColumn(2, "Type", width=70)
-        self.local_file_list.InsertColumn(3, "Modified", width=130)
-        self.local_file_list.InsertColumn(4, "Permissions", width=100)
+        self.local_file_list = self._create_file_list(local_panel, "Local Files pane")
         local_sizer.Add(self.local_file_list, 1, wx.EXPAND)
         local_panel.SetSizer(local_sizer)
 
@@ -298,13 +300,7 @@ class MainFrame(wx.Frame):
         self.remote_path_bar.SetName("Remote Path")
         remote_sizer.Add(self.remote_path_bar, 0, wx.EXPAND | wx.ALL, 2)
 
-        self.remote_file_list = wx.ListCtrl(remote_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.remote_file_list.SetName("Remote")
-        self.remote_file_list.InsertColumn(0, "Name", width=200)
-        self.remote_file_list.InsertColumn(1, "Size", width=80)
-        self.remote_file_list.InsertColumn(2, "Type", width=70)
-        self.remote_file_list.InsertColumn(3, "Modified", width=130)
-        self.remote_file_list.InsertColumn(4, "Permissions", width=100)
+        self.remote_file_list = self._create_file_list(remote_panel, "Remote Files pane")
         remote_sizer.Add(self.remote_file_list, 1, wx.EXPAND)
         remote_panel.SetSizer(remote_sizer)
 
@@ -344,8 +340,8 @@ class MainFrame(wx.Frame):
         """Set startup focus to local files pane."""
         try:
             if self.local_file_list.GetItemCount() > 0:
-                self.local_file_list.Select(0)
-                self.local_file_list.Focus(0)
+                self._select_row(self.local_file_list, 0)
+                self._focus_row(self.local_file_list, 0)
             self.local_file_list.SetFocus()
         except Exception:
             logger.debug("Failed to set initial focus", exc_info=True)
@@ -360,7 +356,7 @@ class MainFrame(wx.Frame):
         focused = self.FindFocus()
         return focused is self.remote_file_list
 
-    def _get_focused_file_list(self) -> wx.ListCtrl | None:
+    def _get_focused_file_list(self) -> FileListCtrl | None:
         """Return whichever file list has focus, or None."""
         focused = self.FindFocus()
         if focused is self.local_file_list:
@@ -406,12 +402,12 @@ class MainFrame(wx.Frame):
         self.tb_connect_btn.Bind(wx.EVT_BUTTON, self._on_connect_toolbar)
 
         # File list events - remote
-        self.remote_file_list.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_remote_item_activated)
+        self.remote_file_list.Bind(dv.EVT_DATAVIEW_ITEM_ACTIVATED, self._on_remote_item_activated)
         self.remote_file_list.Bind(wx.EVT_KEY_DOWN, self._on_remote_file_list_key)
         self.remote_file_list.Bind(wx.EVT_CONTEXT_MENU, self._on_remote_context_menu)
 
         # File list events - local
-        self.local_file_list.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_local_item_activated)
+        self.local_file_list.Bind(dv.EVT_DATAVIEW_ITEM_ACTIVATED, self._on_local_item_activated)
         self.local_file_list.Bind(wx.EVT_KEY_DOWN, self._on_local_file_list_key)
         self.local_file_list.Bind(wx.EVT_CONTEXT_MENU, self._on_local_context_menu)
 
@@ -729,8 +725,8 @@ class MainFrame(wx.Frame):
         self._update_title()
         # Select first item so screen readers announce the new directory
         if self.remote_file_list.GetItemCount() > 0:
-            self.remote_file_list.Select(0)
-            self.remote_file_list.Focus(0)
+            self._select_row(self.remote_file_list, 0)
+            self._focus_row(self.remote_file_list, 0)
             if restore_focus:
                 self.remote_file_list.SetFocus()
         count = len(self._get_visible_files(self._remote_files, self._remote_filter_text))
@@ -763,8 +759,8 @@ class MainFrame(wx.Frame):
             self.local_path_bar.SetValue(self._local_cwd)
             # Select first item so screen readers announce the new directory
             if self.local_file_list.GetItemCount() > 0:
-                self.local_file_list.Select(0)
-                self.local_file_list.Focus(0)
+                self._select_row(self.local_file_list, 0)
+                self._focus_row(self.local_file_list, 0)
                 if restore_focus:
                     self.local_file_list.SetFocus()
             count = len(self._get_visible_files(self._local_files, self._local_filter_text))
@@ -805,14 +801,24 @@ class MainFrame(wx.Frame):
         key_fn = key_map.get(self._settings.display.sort_by, key_map["name"])
         files.sort(key=key_fn, reverse=not self._settings.display.sort_ascending)
 
-    def _populate_file_list(self, list_ctrl: wx.ListCtrl, files: list[RemoteFile]) -> None:
+    def _populate_file_list(self, list_ctrl: FileListCtrl, files: list[RemoteFile]) -> None:
         list_ctrl.DeleteAllItems()
         for f in files:
-            idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), f.name)
-            list_ctrl.SetItem(idx, 1, f.display_size)
-            list_ctrl.SetItem(idx, 2, "Directory" if f.is_dir else "File")
-            list_ctrl.SetItem(idx, 3, f.display_modified)
-            list_ctrl.SetItem(idx, 4, f.permissions)
+            row = [
+                f.name,
+                f.display_size,
+                "Directory" if f.is_dir else "File",
+                f.display_modified,
+                f.permissions,
+            ]
+            if hasattr(list_ctrl, "AppendItem"):
+                list_ctrl.AppendItem(row)
+            else:
+                idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), row[0])
+                list_ctrl.SetItem(idx, 1, row[1])
+                list_ctrl.SetItem(idx, 2, row[2])
+                list_ctrl.SetItem(idx, 3, row[3])
+                list_ctrl.SetItem(idx, 4, row[4])
 
     def _on_toggle_hidden(self, event: wx.CommandEvent) -> None:
         self._settings.display.show_hidden_files = event.IsChecked()
@@ -865,9 +871,9 @@ class MainFrame(wx.Frame):
     # --- Selection helpers ---
 
     def _get_selected_file_from_list(
-        self, list_ctrl: wx.ListCtrl, files: list[RemoteFile], filter_text: str
+        self, list_ctrl: FileListCtrl, files: list[RemoteFile], filter_text: str
     ) -> RemoteFile | None:
-        idx = list_ctrl.GetFirstSelected()
+        idx = self._get_selected_row(list_ctrl)
         if idx == wx.NOT_FOUND:
             return None
         visible = self._get_visible_files(files, filter_text)
@@ -891,12 +897,10 @@ class MainFrame(wx.Frame):
 
     # --- Item activation ---
 
-    def _on_remote_item_activated(self, event: wx.ListEvent) -> None:
+    def _on_remote_item_activated(self, event: wx.Event) -> None:
         f = self._get_selected_remote_file()
         if not f:
-            logger.warning(
-                "Remote item activated but no file selected (index: %s)", event.GetIndex()
-            )
+            logger.warning("Remote item activated but no file selected")
             return
         if not self._client:
             logger.warning("Remote item activated but no client")
@@ -931,7 +935,7 @@ class MainFrame(wx.Frame):
             self._status(f"{f.name} detected as file, not directory")
             self._on_download(None)
 
-    def _on_local_item_activated(self, event: wx.ListEvent) -> None:
+    def _on_local_item_activated(self, event: wx.Event) -> None:
         f = self._get_selected_local_file()
         if not f:
             return
@@ -944,8 +948,40 @@ class MainFrame(wx.Frame):
                 self._on_upload(None)
 
     # Keep old name for compat
-    def _on_item_activated(self, event: wx.ListEvent) -> None:
+    def _on_item_activated(self, event: wx.Event) -> None:
         self._on_remote_item_activated(event)
+
+    def _create_file_list(self, parent: wx.Window, accessible_name: str) -> FileListCtrl:
+        style = dv.DV_SINGLE | dv.DV_ROW_LINES | dv.DV_VERT_RULES
+        list_ctrl = dv.DataViewListCtrl(parent, style=style)
+        list_ctrl.SetName(accessible_name)
+        list_ctrl.AppendTextColumn("Name", width=200)
+        list_ctrl.AppendTextColumn("Size", width=80)
+        list_ctrl.AppendTextColumn("Type", width=70)
+        list_ctrl.AppendTextColumn("Modified", width=130)
+        list_ctrl.AppendTextColumn("Permissions", width=100)
+        return list_ctrl
+
+    def _get_selected_row(self, list_ctrl: FileListCtrl) -> int:
+        if hasattr(list_ctrl, "GetSelectedRow"):
+            return list_ctrl.GetSelectedRow()
+        if hasattr(list_ctrl, "GetFirstSelected"):
+            return list_ctrl.GetFirstSelected()
+        return wx.NOT_FOUND
+
+    def _select_row(self, list_ctrl: FileListCtrl, idx: int) -> None:
+        if hasattr(list_ctrl, "SelectRow"):
+            list_ctrl.SelectRow(idx)
+            return
+        if hasattr(list_ctrl, "Select"):
+            list_ctrl.Select(idx)
+
+    def _focus_row(self, list_ctrl: FileListCtrl, idx: int) -> None:
+        if hasattr(list_ctrl, "SetCurrentRow"):
+            list_ctrl.SetCurrentRow(idx)
+            return
+        if hasattr(list_ctrl, "Focus"):
+            list_ctrl.Focus(idx)
 
     # --- Keyboard handling ---
 

--- a/tests/_wx_stub.py
+++ b/tests/_wx_stub.py
@@ -62,9 +62,15 @@ class _SimpleWidget(MagicMock):
         self.SetSizer = MagicMock()
         self.InsertItem = MagicMock(return_value=0)
         self.SetItem = MagicMock()
+        self.AppendItem = MagicMock()
+        self.AppendTextColumn = MagicMock()
+        self.DeleteAllItems = MagicMock()
         self.GetItemCount = MagicMock(return_value=0)
+        self.GetSelectedRow = MagicMock(return_value=-1)
         self.Select = MagicMock()
+        self.SelectRow = MagicMock()
         self.Focus = MagicMock()
+        self.SetCurrentRow = MagicMock()
         self.SetValue = MagicMock()
         self.GetValue = MagicMock()
 
@@ -189,6 +195,14 @@ def _create_fake_wx() -> tuple[types.ModuleType, types.ModuleType]:
     fake_adv.AboutBox = lambda info: None
     fake_wx.adv = fake_adv
 
+    fake_dv = types.ModuleType("wx.dataview")
+    fake_dv.DataViewListCtrl = lambda *args, **kwargs: _SimpleWidget()
+    fake_dv.EVT_DATAVIEW_ITEM_ACTIVATED = object()
+    fake_dv.DV_SINGLE = 1
+    fake_dv.DV_ROW_LINES = 2
+    fake_dv.DV_VERT_RULES = 4
+    fake_wx.dataview = fake_dv
+
     return fake_wx, fake_adv
 
 
@@ -198,6 +212,7 @@ def load_module_with_fake_wx(
     fake_wx, fake_adv = _create_fake_wx()
     monkeypatch.setitem(sys.modules, "wx", fake_wx)
     monkeypatch.setitem(sys.modules, "wx.adv", fake_adv)
+    monkeypatch.setitem(sys.modules, "wx.dataview", fake_wx.dataview)
     sys.modules.pop(module_name, None)
     module = importlib.import_module(module_name)
     return module, fake_wx

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -949,6 +949,127 @@ def test_on_remote_item_activated_file_sets_status(app_module):
     threading.Thread = original_thread
 
 
+def test_create_file_list_sets_accessible_name_and_columns(app_module):
+    app, _ = app_module
+    frame = object.__new__(app.MainFrame)
+    list_ctrl = MagicMock(SetName=MagicMock(), AppendTextColumn=MagicMock())
+
+    with patch.object(app.dv, "DataViewListCtrl", return_value=list_ctrl) as dv_list:
+        created = app.MainFrame._create_file_list(frame, MagicMock(), "Remote Files pane")
+
+    assert created is list_ctrl
+    dv_list.assert_called_once()
+    list_ctrl.SetName.assert_called_once_with("Remote Files pane")
+    assert list_ctrl.AppendTextColumn.call_count == 5
+
+
+def test_populate_file_list_uses_append_item_when_available(app_module):
+    app, _ = app_module
+    frame = object.__new__(app.MainFrame)
+    from portkeydrop.protocols import RemoteFile
+
+    list_ctrl = MagicMock(DeleteAllItems=MagicMock(), AppendItem=MagicMock())
+    files = [RemoteFile(name="a.txt", path="/a.txt", permissions="rw-r--r--")]
+
+    app.MainFrame._populate_file_list(frame, list_ctrl, files)
+
+    list_ctrl.DeleteAllItems.assert_called_once()
+    list_ctrl.AppendItem.assert_called_once()
+
+
+class _LegacyListCtrl:
+    def __init__(self):
+        self.rows: list[list[str]] = []
+
+    def DeleteAllItems(self):
+        self.rows.clear()
+
+    def GetItemCount(self):
+        return len(self.rows)
+
+    def InsertItem(self, idx, text):
+        self.rows.insert(idx, [text, "", "", "", ""])
+        return idx
+
+    def SetItem(self, idx, col, value):
+        self.rows[idx][col] = value
+
+
+def test_populate_file_list_falls_back_to_insert_item_for_listctrl(app_module):
+    app, _ = app_module
+    frame = object.__new__(app.MainFrame)
+    from portkeydrop.protocols import RemoteFile
+
+    list_ctrl = _LegacyListCtrl()
+    files = [RemoteFile(name="docs", path="/docs", is_dir=True, permissions="drwxr-xr-x")]
+
+    app.MainFrame._populate_file_list(frame, list_ctrl, files)
+
+    assert list_ctrl.rows[0][0] == "docs"
+    assert list_ctrl.rows[0][2] == "Directory"
+
+
+def test_selected_row_helpers_cover_all_control_types(app_module):
+    app, fake_wx = app_module
+    frame = object.__new__(app.MainFrame)
+
+    dataview = MagicMock(GetSelectedRow=MagicMock(return_value=3))
+    assert app.MainFrame._get_selected_row(frame, dataview) == 3
+
+    listctrl = MagicMock()
+    del listctrl.GetSelectedRow
+    listctrl.GetFirstSelected = MagicMock(return_value=2)
+    assert app.MainFrame._get_selected_row(frame, listctrl) == 2
+
+    bare = object()
+    assert app.MainFrame._get_selected_row(frame, bare) == fake_wx.NOT_FOUND
+
+
+def test_select_and_focus_row_helpers_cover_fallbacks(app_module):
+    app, _ = app_module
+    frame = object.__new__(app.MainFrame)
+
+    dataview = MagicMock(SelectRow=MagicMock(), SetCurrentRow=MagicMock())
+    app.MainFrame._select_row(frame, dataview, 1)
+    app.MainFrame._focus_row(frame, dataview, 1)
+    dataview.SelectRow.assert_called_once_with(1)
+    dataview.SetCurrentRow.assert_called_once_with(1)
+
+    listctrl = MagicMock(Select=MagicMock(), Focus=MagicMock())
+    del listctrl.SelectRow
+    del listctrl.SetCurrentRow
+    app.MainFrame._select_row(frame, listctrl, 4)
+    app.MainFrame._focus_row(frame, listctrl, 4)
+    listctrl.Select.assert_called_once_with(4)
+    listctrl.Focus.assert_called_once_with(4)
+
+
+def test_get_selected_file_from_list_returns_none_when_no_row(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._get_selected_row = MagicMock(return_value=-1)
+
+    selected = app.MainFrame._get_selected_file_from_list(frame, MagicMock(), [], "")
+
+    assert selected is None
+
+
+def test_on_remote_item_activated_without_client_is_noop(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    from portkeydrop.protocols import RemoteFile
+
+    frame._get_selected_remote_file = MagicMock(
+        return_value=RemoteFile(name="docs", path="/remote/docs", is_dir=True)
+    )
+    frame._client = None
+    frame._status = MagicMock()
+
+    app.MainFrame._on_remote_item_activated(frame, MagicMock())
+
+    frame._status.assert_not_called()
+
+
 def test_get_update_channel_reads_settings(app_module):
     app, _ = app_module
     frame = object.__new__(app.MainFrame)


### PR DESCRIPTION
## Summary
- replace local/remote main pane file controls from wx.ListCtrl to wx.dataview.DataViewListCtrl
- preserve existing columns, keyboard handlers, activation behavior, context menus, filtering, refresh flow, and F6 pane switching
- add compatibility helpers for selection/focus to keep current UX while improving semantics
- update wx test stub for wx.dataview and add changelog entry

## Validation
- `uv run --no-project --with pytest --with pytest-cov --with pytest-xdist --with ruff ruff check src tests`
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-cov --with pytest-xdist --with asyncssh --with puttykeys --with keyring --with prismatoid pytest --cov=src/portkeydrop --cov-report=term-missing`

## Notes
- direct `uv run` with project dependencies fails in this container because building wxpython==4.2.5 requires clang; validation was run with an equivalent dependency set excluding wxpython.
- NVDA verification requires manual check on Windows with screen reader enabled.
