### PR TITLE
fix(transfer): announce accessible progress details

### DIFF
--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -27,7 +27,7 @@ from portkeydrop.dialogs.transfer import (
     load_queue,
     save_queue,
 )
-from portkeydrop.services.transfer_service import TransferService
+from portkeydrop.services.transfer_service import TransferService, format_transfer_detail
 from portkeydrop.local_files import (
     delete_local,
     list_local_dir,
@@ -122,6 +122,7 @@ class MainFrame(wx.Frame):
             max_workers=self._settings.transfer.concurrent_transfers,
         )
         self._transfer_state_by_id: dict[str, str] = {}
+        self._transfer_progress_by_id: dict[str, int] = {}
         self._last_failed_transfer: str | None = None
         self._announcer = ScreenReaderAnnouncer()
         self._restore_transfer_queue()
@@ -1539,19 +1540,29 @@ class MainFrame(wx.Frame):
         for job in self._transfer_service.jobs:
             current_state = job.status.value
             previous_state = self._transfer_state_by_id.get(job.id)
-            if current_state == previous_state:
+            state_changed = current_state != previous_state
+            if not state_changed and job.status != TransferStatus.IN_PROGRESS:
                 continue
 
-            self._transfer_state_by_id[job.id] = current_state
+            if state_changed:
+                self._transfer_state_by_id[job.id] = current_state
             direction_label = "Upload" if job.direction == TransferDirection.UPLOAD else "Download"
             filename = os.path.basename(job.destination) or PurePosixPath(job.source).name
 
             if job.status == TransferStatus.PENDING:
                 latest_status_message = f"{direction_label} queued."
             elif job.status == TransferStatus.IN_PROGRESS:
-                latest_status_message = f"{direction_label} in progress..."
+                progress_message = self._format_transfer_progress_message(
+                    job, direction_label, filename
+                )
+                latest_status_message = (
+                    f"{direction_label} in progress..." if state_changed else progress_message
+                )
+                if self._should_announce_transfer_progress(job):
+                    self._announce(progress_message)
             elif job.status == TransferStatus.COMPLETE:
                 latest_status_message = f"{direction_label} complete."
+                self._clear_transfer_progress(job.id)
                 self.log_event(f"{direction_label} complete: {filename}")
                 if job.direction == TransferDirection.DOWNLOAD:
                     refresh_local_files = True
@@ -1559,6 +1570,7 @@ class MainFrame(wx.Frame):
                     refresh_remote_files = True
             elif job.status == TransferStatus.FAILED:
                 latest_status_message = f"{direction_label} failed."
+                self._clear_transfer_progress(job.id)
                 error_msg = job.error or "Unknown error"
                 self.log_event(f"{direction_label} failed: {filename} — {error_msg}")
                 self._announce(f"{direction_label} failed.")
@@ -1566,6 +1578,7 @@ class MainFrame(wx.Frame):
                 self._retry_last_failed_item.Enable(True)
             elif job.status == TransferStatus.CANCELLED:
                 latest_status_message = f"{direction_label} cancelled."
+                self._clear_transfer_progress(job.id)
                 self.log_event(f"{direction_label} cancelled: {filename}")
 
         if refresh_local_files:
@@ -1576,6 +1589,33 @@ class MainFrame(wx.Frame):
         if latest_status_message:
             current_path = self._client.cwd if self._client and self._client.connected else ""
             self._update_status(latest_status_message, current_path)
+
+    def _format_transfer_progress_message(self, job, direction_label: str, filename: str) -> str:
+        return f"{direction_label} {filename} {job.progress}%, {format_transfer_detail(job)}"
+
+    def _should_announce_transfer_progress(self, job) -> bool:
+        settings = getattr(self, "_settings", None)
+        display_settings = getattr(settings, "display", None)
+        interval = max(1, int(getattr(display_settings, "progress_interval", 25)))
+        if job.progress <= 0:
+            return False
+        bucket = min(100, (int(job.progress) // interval) * interval)
+        if bucket <= 0:
+            return False
+        progress_by_id = getattr(self, "_transfer_progress_by_id", None)
+        if progress_by_id is None:
+            progress_by_id = {}
+            self._transfer_progress_by_id = progress_by_id
+        previous_bucket = progress_by_id.get(job.id, 0)
+        if bucket <= previous_bucket:
+            return False
+        progress_by_id[job.id] = bucket
+        return True
+
+    def _clear_transfer_progress(self, job_id: str) -> None:
+        progress_by_id = getattr(self, "_transfer_progress_by_id", None)
+        if progress_by_id is not None:
+            progress_by_id.pop(job_id, None)
 
     def _on_settings(self, event: wx.CommandEvent) -> None:
         dlg = SettingsDialog(

--- a/src/portkeydrop/dialogs/transfer.py
+++ b/src/portkeydrop/dialogs/transfer.py
@@ -19,6 +19,7 @@ from portkeydrop.services.transfer_service import (  # noqa: F401
     TransferJob,
     TransferService,
     TransferStatus,
+    format_transfer_detail,
     get_transfer_event_binder,
 )
 
@@ -100,7 +101,8 @@ def create_transfer_dialog(parent, transfer_service: TransferService, log_callba
             self.transfer_list.InsertColumn(0, "File", width=200)
             self.transfer_list.InsertColumn(1, "Direction", width=80)
             self.transfer_list.InsertColumn(2, "Progress", width=80)
-            self.transfer_list.InsertColumn(3, "Status", width=100)
+            self.transfer_list.InsertColumn(3, "Transferred", width=130)
+            self.transfer_list.InsertColumn(4, "Status", width=100)
             sizer.Add(self.transfer_list, 1, wx.EXPAND | wx.ALL, 8)
 
             btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -267,7 +269,13 @@ def create_transfer_dialog(parent, transfer_service: TransferService, log_callba
                 display_status = (
                     f"{j.progress}%" if j.status == TransferStatus.IN_PROGRESS else j.status.value
                 )
-                cols = [name, j.direction.value, f"{j.progress}%", display_status]
+                cols = [
+                    name,
+                    j.direction.value,
+                    f"{j.progress}%",
+                    format_transfer_detail(j),
+                    display_status,
+                ]
                 if i >= current_count:
                     row = self.transfer_list.InsertItem(i, cols[0])
                     for col_idx in range(1, len(cols)):

--- a/src/portkeydrop/services/transfer_service.py
+++ b/src/portkeydrop/services/transfer_service.py
@@ -91,6 +91,31 @@ class TransferJob:
         )
 
 
+def format_bytes(byte_count: int) -> str:
+    """Return a compact human-readable byte count for transfer progress."""
+    size = max(0, int(byte_count))
+    units = ("B", "KB", "MB", "GB", "TB")
+    value = float(size)
+    for unit in units:
+        if unit == "B":
+            if value < 1024:
+                return f"{int(value)} B"
+        elif value < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} PB"
+
+
+def format_transfer_detail(job: TransferJob) -> str:
+    """Return byte-level progress text for queue rows and speech output."""
+    transferred_bytes = int(getattr(job, "transferred_bytes", 0) or 0)
+    total_bytes = int(getattr(job, "total_bytes", 0) or 0)
+    transferred = format_bytes(transferred_bytes)
+    if total_bytes > 0:
+        return f"{transferred} of {format_bytes(total_bytes)}"
+    return f"{transferred} transferred"
+
+
 @dataclass
 class _Worker:
     """Tracks a worker thread and its stop signal for pool replacement."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -75,6 +75,9 @@ def _hydrate_frame(module):
     frame._get_selected_local_file = MagicMock()
     frame._get_selected_remote_file = MagicMock()
     frame._transfer_service = MagicMock()
+    frame._transfer_state_by_id = {}
+    frame._transfer_progress_by_id = {}
+    frame._settings = SimpleNamespace(display=SimpleNamespace(progress_interval=25))
     frame.status_bar = MagicMock(SetStatusText=MagicMock())
     frame.activity_log = MagicMock()
     frame._activity_log_visible = True
@@ -82,6 +85,33 @@ def _hydrate_frame(module):
     frame._retry_last_failed_item = MagicMock()
     frame._toolbar_panel = MagicMock()
     return frame
+
+
+def test_on_transfer_update_announces_progress_at_configured_interval(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = None
+    job = SimpleNamespace(
+        id="job-progress",
+        direction=app.TransferDirection.DOWNLOAD,
+        source="/remote/report.zip",
+        destination="C:/Users/joshu/Downloads/report.zip",
+        status=app.TransferStatus.IN_PROGRESS,
+        progress=24,
+        transferred_bytes=24,
+        total_bytes=100,
+    )
+    frame._transfer_service.jobs = [job]
+
+    frame._on_transfer_update(None)
+    frame._announce.assert_not_called()
+
+    job.progress = 25
+    job.transferred_bytes = 25
+    frame._on_transfer_update(None)
+
+    frame._announce.assert_called_once_with("Download report.zip 25%, 25 B of 100 B")
+    frame._update_status.assert_called_with("Download report.zip 25%, 25 B of 100 B", "")
 
 
 def test_main_frame_init_sets_transfer_state(tmp_path, app_module):

--- a/tests/test_retry_failed_transfers.py
+++ b/tests/test_retry_failed_transfers.py
@@ -392,7 +392,7 @@ class FakeListCtrl:
         pass
 
     def InsertItem(self, index, label):
-        row = [label, "", "", ""]
+        row = [label, "", "", "", ""]
         if index >= len(self._rows):
             self._rows.append(row)
         else:

--- a/tests/test_transfer_dialog_refresh.py
+++ b/tests/test_transfer_dialog_refresh.py
@@ -54,7 +54,15 @@ def transfer_module(monkeypatch):
     return module, fake_wx
 
 
-def _make_job(transfer_id, path, direction="download", progress=0, status="pending"):
+def _make_job(
+    transfer_id,
+    path,
+    direction="download",
+    progress=0,
+    status="pending",
+    transferred_bytes=0,
+    total_bytes=0,
+):
     from portkeydrop.services.transfer_service import TransferDirection, TransferStatus
 
     return SimpleNamespace(
@@ -63,6 +71,8 @@ def _make_job(transfer_id, path, direction="download", progress=0, status="pendi
         destination="/tmp/" + path.rsplit("/", 1)[-1],
         direction=TransferDirection.UPLOAD if direction == "upload" else TransferDirection.DOWNLOAD,
         progress=progress,
+        transferred_bytes=transferred_bytes,
+        total_bytes=total_bytes,
         status=TransferStatus(status),
     )
 
@@ -108,8 +118,30 @@ def test_refresh_adds_new_transfers_when_row_missing(transfer_module):
     dialog._refresh()
 
     transfer_list.InsertItem.assert_has_calls([call(0, "a.txt"), call(1, "b.txt")])
-    assert transfer_list.SetItem.call_count == 6
+    assert transfer_list.SetItem.call_count == 8
     transfer_list.DeleteAllItems.assert_not_called()
+
+
+def test_refresh_shows_transferred_bytes_as_progress_detail(transfer_module):
+    module, fake_wx = transfer_module
+    dialog, transfer_list, service = _build_dialog(module, fake_wx)
+    service.jobs = [
+        _make_job(
+            "j3",
+            "/tmp/archive.zip",
+            "download",
+            progress=50,
+            status="in_progress",
+            transferred_bytes=1024,
+            total_bytes=2048,
+        ),
+    ]
+    transfer_list.GetItemCount.return_value = 0
+
+    dialog._refresh()
+
+    transfer_list.SetItem.assert_any_call(0, 3, "1.0 KB of 2.0 KB")
+    transfer_list.SetItem.assert_any_call(0, 4, "50%")
 
 
 def test_refresh_updates_only_changed_existing_cells(transfer_module):
@@ -122,7 +154,7 @@ def test_refresh_updates_only_changed_existing_cells(transfer_module):
     dialog._refresh()
 
     transfer_list.InsertItem.assert_not_called()
-    assert transfer_list.SetItem.call_count == 4
+    assert transfer_list.SetItem.call_count == 5
     transfer_list.DeleteAllItems.assert_not_called()
 
 
@@ -133,7 +165,7 @@ def test_refresh_does_not_set_item_when_values_unchanged(transfer_module):
         _make_job("j11", "/tmp/same.txt", "download", progress=50, status="in_progress")
     ]
     transfer_list.GetItemCount.return_value = 1
-    current_values = ["same.txt", "download", "50%", "50%"]
+    current_values = ["same.txt", "download", "50%", "0 B transferred", "50%"]
     transfer_list.GetItemText.side_effect = lambda _row, col: current_values[col]
 
     dialog._refresh()


### PR DESCRIPTION
## Summary

- Add byte-level transfer detail formatting for queue rows and speech output.
- Add a Transferred column to the transfer queue so users can inspect bytes moved, not only percent.
- Announce in-progress transfer updates at the configured progress interval without repeating the same bucket.

## Scope

This PR intentionally stays focused on accessible progress reporting. Overwrite/skip/rename policy enforcement and SCP/WebDAV documentation alignment should be handled in follow-up PRs because they touch different product decisions and review surfaces.

## Verification

- `uv run ruff check src tests`
- `uv run python -m pytest -q --tb=short tests/test_transfer_dialog_refresh.py tests/test_transfer_queue_a11y.py tests/test_app.py tests/test_activity_log.py tests/test_transfer_service.py tests/test_transfer_persist.py tests/test_retry_failed_transfers.py::TestRetryButtonState`

## Known Existing Full-Suite Failures

A full local run also reported two Windows path expectation failures outside this change:

- `tests/test_importers_winscp.py::test_detect_ini_path_appdata`
- `tests/test_local_files.py::TestParentLocal::test_parent_of_root`