### PR TITLE
fix(transfer): enforce overwrite policy before enqueue

### DIFF
--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -1253,14 +1253,30 @@ class MainFrame(wx.Frame):
         if not f or not self._client:
             return
         local_path = os.path.join(self._local_cwd, f.name)
+        planned_path = self._resolve_local_transfer_conflict(local_path, f.name, "download")
+        if planned_path is None:
+            return
+        overwrite_existing = planned_path == local_path and os.path.exists(local_path)
         if f.is_dir:
             if f.name == "..":
                 return
-            self._transfer_service.submit_download(self._client, f.path, local_path, recursive=True)
-            self._announce(f"Downloading folder {f.name} to {self._local_cwd}")
+            self._transfer_service.submit_download(
+                self._client,
+                f.path,
+                planned_path,
+                recursive=True,
+                overwrite_existing=overwrite_existing,
+            )
+            self._announce(f"Downloading folder {f.name} to {os.path.dirname(planned_path)}")
         else:
-            self._transfer_service.submit_download(self._client, f.path, local_path, f.size)
-            self._announce(f"Downloading {f.name} to {self._local_cwd}")
+            self._transfer_service.submit_download(
+                self._client,
+                f.path,
+                planned_path,
+                f.size,
+                overwrite_existing=overwrite_existing,
+            )
+            self._announce(f"Downloading {f.name} to {os.path.dirname(planned_path)}")
         self._show_transfer_queue()
 
     def _on_upload(self, event) -> None:
@@ -1272,20 +1288,123 @@ class MainFrame(wx.Frame):
         local_path = f.path
         filename = f.name
         remote_path = f"{self._client.cwd.rstrip('/')}/{filename}"
+        planned_remote_path = self._resolve_remote_transfer_conflict(
+            remote_path, filename, "upload"
+        )
+        if planned_remote_path is None:
+            return
+        overwrite_existing = planned_remote_path == remote_path and self._remote_path_exists(
+            remote_path
+        )
         if f.is_dir:
             if f.name == "..":
                 return
             self._transfer_service.submit_upload(
-                self._client, local_path, remote_path, recursive=True
+                self._client,
+                local_path,
+                planned_remote_path,
+                recursive=True,
+                overwrite_existing=overwrite_existing,
             )
             self._announce(f"Uploading folder {filename}")
             self._update_status(f"Uploading folder {filename}...", self._client.cwd)
         else:
             total = os.path.getsize(local_path)
-            self._transfer_service.submit_upload(self._client, local_path, remote_path, total)
+            self._transfer_service.submit_upload(
+                self._client,
+                local_path,
+                planned_remote_path,
+                total,
+                overwrite_existing=overwrite_existing,
+            )
             self._announce(f"Uploading {filename}")
             self._update_status(f"Uploading {filename}...", self._client.cwd)
         self._show_transfer_queue()
+
+    def _transfer_overwrite_mode(self) -> str:
+        transfer_settings = getattr(getattr(self, "_settings", None), "transfer", None)
+        mode = getattr(transfer_settings, "overwrite_mode", "ask")
+        return mode if mode in {"ask", "overwrite", "skip", "rename"} else "ask"
+
+    def _resolve_local_transfer_conflict(
+        self, local_path: str, filename: str, action: str
+    ) -> str | None:
+        if not os.path.exists(local_path):
+            return local_path
+        mode = self._transfer_overwrite_mode()
+        if mode == "overwrite":
+            return local_path
+        if mode == "skip":
+            self._announce(f"Skipped {action}; {filename} already exists")
+            return None
+        if mode == "rename":
+            return self._unique_local_path(local_path)
+        if self._confirm_overwrite(filename, action):
+            return local_path
+        self._announce(f"Skipped {action}; {filename} already exists")
+        return None
+
+    def _resolve_remote_transfer_conflict(
+        self, remote_path: str, filename: str, action: str
+    ) -> str | None:
+        if not self._remote_path_exists(remote_path):
+            return remote_path
+        mode = self._transfer_overwrite_mode()
+        if mode == "overwrite":
+            return remote_path
+        if mode == "skip":
+            self._announce(f"Skipped {action}; {filename} already exists")
+            return None
+        if mode == "rename":
+            return self._unique_remote_path(remote_path)
+        if self._confirm_overwrite(filename, action):
+            return remote_path
+        self._announce(f"Skipped {action}; {filename} already exists")
+        return None
+
+    def _confirm_overwrite(self, filename: str, action: str) -> bool:
+        result = wx.MessageBox(
+            f"{filename} already exists. Overwrite it?",
+            f"Confirm {action.title()} Overwrite",
+            wx.YES_NO | wx.ICON_WARNING,
+            self,
+        )
+        return result == wx.YES
+
+    @staticmethod
+    def _unique_local_path(path: str) -> str:
+        if not os.path.exists(path):
+            return path
+        directory, filename = os.path.split(path)
+        stem, ext = os.path.splitext(filename)
+        counter = 1
+        while True:
+            candidate = os.path.join(directory, f"{stem} ({counter}){ext}")
+            if not os.path.exists(candidate):
+                return candidate
+            counter += 1
+
+    def _unique_remote_path(self, path: str) -> str:
+        if not self._remote_path_exists(path):
+            return path
+        parent, _, filename = path.rpartition("/")
+        stem, ext = os.path.splitext(filename)
+        counter = 1
+        while True:
+            candidate_name = f"{stem} ({counter}){ext}"
+            candidate = f"{parent}/{candidate_name}" if parent else candidate_name
+            if not self._remote_path_exists(candidate):
+                return candidate
+            counter += 1
+
+    def _remote_path_exists(self, path: str) -> bool:
+        if not self._client:
+            return False
+        try:
+            self._client.stat(path)
+            return True
+        except Exception:
+            return False
 
     def _get_clipboard_files(self) -> list[str]:
         """Get file paths from the system clipboard."""
@@ -1315,13 +1434,31 @@ class MainFrame(wx.Frame):
                 continue
             filename = p.name
             remote_path = f"{self._client.cwd.rstrip('/')}/{filename}"
+            planned_remote_path = self._resolve_remote_transfer_conflict(
+                remote_path, filename, "upload"
+            )
+            if planned_remote_path is None:
+                continue
+            overwrite_existing = planned_remote_path == remote_path and self._remote_path_exists(
+                remote_path
+            )
             if p.is_dir():
                 self._transfer_service.submit_upload(
-                    self._client, str(p), remote_path, recursive=True
+                    self._client,
+                    str(p),
+                    planned_remote_path,
+                    recursive=True,
+                    overwrite_existing=overwrite_existing,
                 )
             else:
                 total = os.path.getsize(str(p))
-                self._transfer_service.submit_upload(self._client, str(p), remote_path, total)
+                self._transfer_service.submit_upload(
+                    self._client,
+                    str(p),
+                    planned_remote_path,
+                    total,
+                    overwrite_existing=overwrite_existing,
+                )
             count += 1
         if count:
             self._announce(

--- a/src/portkeydrop/services/transfer_service.py
+++ b/src/portkeydrop/services/transfer_service.py
@@ -52,6 +52,7 @@ class TransferJob:
     progress: int = 0  # 0-100
     total_bytes: int = 0
     transferred_bytes: int = 0
+    overwrite_existing: bool = False
     cancel_event: threading.Event = field(default_factory=threading.Event)
     # Internal: client + recursive flag (not part of the public data model)
     _client: TransferClient | None = field(default=None, repr=False)
@@ -71,6 +72,7 @@ class TransferJob:
             "protocol": self.protocol,
             "total_bytes": self.total_bytes,
             "transferred_bytes": self.transferred_bytes,
+            "overwrite_existing": self.overwrite_existing,
             "status": self.status.value,
             "error": self.error or "",
         }
@@ -86,6 +88,7 @@ class TransferJob:
             protocol=data.get("protocol", ""),
             total_bytes=data.get("total_bytes", 0),
             transferred_bytes=data.get("transferred_bytes", 0),
+            overwrite_existing=bool(data.get("overwrite_existing", False)),
             status=TransferStatus.RESTORED,
             error=data.get("error") or None,
         )
@@ -153,6 +156,7 @@ class TransferService:
         total_bytes: int = 0,
         *,
         recursive: bool = False,
+        overwrite_existing: bool = False,
     ) -> TransferJob:
         job = TransferJob(
             direction=TransferDirection.DOWNLOAD,
@@ -160,6 +164,7 @@ class TransferService:
             destination=local_path,
             protocol=getattr(client, "_protocol_name", "sftp"),
             total_bytes=total_bytes,
+            overwrite_existing=overwrite_existing,
             _client=client,
             _recursive=recursive,
         )
@@ -174,6 +179,7 @@ class TransferService:
         total_bytes: int = 0,
         *,
         recursive: bool = False,
+        overwrite_existing: bool = False,
     ) -> TransferJob:
         job = TransferJob(
             direction=TransferDirection.UPLOAD,
@@ -181,6 +187,7 @@ class TransferService:
             destination=remote_path,
             protocol=getattr(client, "_protocol_name", "sftp"),
             total_bytes=total_bytes,
+            overwrite_existing=overwrite_existing,
             _client=client,
             _recursive=recursive,
         )
@@ -336,10 +343,22 @@ class TransferService:
         client = job._client
 
         # Determine whether we can resume from a previous partial download.
+        had_partial_download = job.transferred_bytes > 0
         offset = self._resolve_download_offset(job, client)
 
-        mode = "r+b" if offset > 0 else "wb"
-        with open(job.destination, mode) as f:
+        if offset > 0:
+            mode = "r+b"
+        elif job.overwrite_existing or had_partial_download:
+            mode = "wb"
+        else:
+            mode = "xb"
+
+        try:
+            f = open(job.destination, mode)
+        except FileExistsError as exc:
+            raise FileExistsError(f"Destination already exists: {job.destination}") from exc
+
+        with f:
             if offset > 0:
                 f.seek(offset)
 
@@ -398,7 +417,12 @@ class TransferService:
                 raise InterruptedError("Transfer cancelled")
             os.makedirs(os.path.dirname(local_file), exist_ok=True)
             base = job.transferred_bytes
-            with open(local_file, "wb") as f:
+            mode = "wb" if job.overwrite_existing else "xb"
+            try:
+                f = open(local_file, mode)
+            except FileExistsError as exc:
+                raise FileExistsError(f"Destination already exists: {local_file}") from exc
+            with f:
 
                 def _cb(transferred: int, total: int, _base=base) -> None:
                     if job.cancel_event.is_set():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,7 +77,6 @@ def _hydrate_frame(module):
     frame._transfer_service = MagicMock()
     frame._transfer_state_by_id = {}
     frame._transfer_progress_by_id = {}
-    frame._settings = SimpleNamespace(display=SimpleNamespace(progress_interval=25))
     frame.status_bar = MagicMock(SetStatusText=MagicMock())
     frame.activity_log = MagicMock()
     frame._activity_log_visible = True
@@ -85,7 +84,9 @@ def _hydrate_frame(module):
     frame._retry_last_failed_item = MagicMock()
     frame._toolbar_panel = MagicMock()
     frame._settings = SimpleNamespace(
-        connection=SimpleNamespace(timeout=45, passive_mode=False, verify_host_keys="never")
+        connection=SimpleNamespace(timeout=45, passive_mode=False, verify_host_keys="never"),
+        display=SimpleNamespace(progress_interval=25),
+        transfer=SimpleNamespace(overwrite_mode="ask"),
     )
     return frame
 
@@ -211,6 +212,7 @@ def test_on_upload_directory_updates_status(app_module):
     app, _ = app_module
     frame = _hydrate_frame(app_module)
     frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._client.stat.side_effect = FileNotFoundError
     selected = MagicMock()
     selected.name = "docs"
     selected.path = "/tmp/docs"
@@ -228,6 +230,7 @@ def test_on_upload_file_reports_progress(app_module):
     app, _ = app_module
     frame = _hydrate_frame(app_module)
     frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._client.stat.side_effect = FileNotFoundError
     selected = MagicMock(name="file.txt")
     selected.is_dir = False
     selected.name = "file.txt"
@@ -242,10 +245,234 @@ def test_on_upload_file_reports_progress(app_module):
     frame._update_status.assert_called_with("Uploading file.txt...", "/remote")
 
 
+def test_on_download_skip_existing_file_does_not_enqueue(tmp_path, app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._local_cwd = str(tmp_path)
+    frame._settings.transfer.overwrite_mode = "skip"
+    existing = tmp_path / "report.txt"
+    existing.write_text("existing")
+    selected = MagicMock()
+    selected.name = "report.txt"
+    selected.path = "/remote/report.txt"
+    selected.is_dir = False
+    selected.size = 123
+    frame._get_selected_remote_file.return_value = selected
+    frame._transfer_service.submit_download = MagicMock()
+
+    frame._on_download(None)
+
+    frame._transfer_service.submit_download.assert_not_called()
+    frame._announce.assert_called_with("Skipped download; report.txt already exists")
+    frame._show_transfer_queue.assert_not_called()
+
+
+def test_on_download_rename_existing_file_before_enqueue(tmp_path, app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._local_cwd = str(tmp_path)
+    frame._settings.transfer.overwrite_mode = "rename"
+    (tmp_path / "report.txt").write_text("existing")
+    selected = MagicMock()
+    selected.name = "report.txt"
+    selected.path = "/remote/report.txt"
+    selected.is_dir = False
+    selected.size = 123
+    frame._get_selected_remote_file.return_value = selected
+    frame._transfer_service.submit_download = MagicMock()
+
+    frame._on_download(None)
+
+    expected = str(tmp_path / "report (1).txt")
+    frame._transfer_service.submit_download.assert_called_once_with(
+        frame._client,
+        "/remote/report.txt",
+        expected,
+        123,
+        overwrite_existing=False,
+    )
+
+
+def test_on_download_existing_folder_overwrite_enqueues_recursive(tmp_path, app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._local_cwd = str(tmp_path)
+    frame._settings.transfer.overwrite_mode = "overwrite"
+    (tmp_path / "docs").mkdir()
+    selected = MagicMock()
+    selected.name = "docs"
+    selected.path = "/remote/docs"
+    selected.is_dir = True
+    frame._get_selected_remote_file.return_value = selected
+    frame._transfer_service.submit_download = MagicMock()
+
+    frame._on_download(None)
+
+    frame._transfer_service.submit_download.assert_called_once_with(
+        frame._client,
+        "/remote/docs",
+        str(tmp_path / "docs"),
+        recursive=True,
+        overwrite_existing=True,
+    )
+    frame._announce.assert_called_with(f"Downloading folder docs to {tmp_path}")
+
+
+def test_on_upload_skip_existing_remote_file_does_not_enqueue(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._client.stat.return_value = SimpleNamespace()
+    frame._settings.transfer.overwrite_mode = "skip"
+    selected = MagicMock()
+    selected.name = "report.txt"
+    selected.path = "/tmp/report.txt"
+    selected.is_dir = False
+    frame._get_selected_local_file.return_value = selected
+    frame._transfer_service.submit_upload = MagicMock()
+
+    with patch.object(app.os.path, "getsize", return_value=123):
+        frame._on_upload(None)
+
+    frame._client.stat.assert_called_once_with("/remote/report.txt")
+    frame._transfer_service.submit_upload.assert_not_called()
+    frame._announce.assert_called_with("Skipped upload; report.txt already exists")
+
+
+def test_on_upload_overwrite_existing_remote_file(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._client.stat.return_value = SimpleNamespace()
+    frame._settings.transfer.overwrite_mode = "overwrite"
+    selected = MagicMock()
+    selected.name = "report.txt"
+    selected.path = "/tmp/report.txt"
+    selected.is_dir = False
+    frame._get_selected_local_file.return_value = selected
+    frame._transfer_service.submit_upload = MagicMock()
+
+    with patch.object(app.os.path, "getsize", return_value=123):
+        frame._on_upload(None)
+
+    frame._transfer_service.submit_upload.assert_called_once_with(
+        frame._client,
+        "/tmp/report.txt",
+        "/remote/report.txt",
+        123,
+        overwrite_existing=True,
+    )
+
+
+def test_on_upload_rename_existing_remote_file_before_enqueue(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._settings.transfer.overwrite_mode = "rename"
+
+    def stat(path):
+        if path == "/remote/report.txt":
+            return SimpleNamespace()
+        raise FileNotFoundError(path)
+
+    frame._client.stat.side_effect = stat
+    selected = MagicMock()
+    selected.name = "report.txt"
+    selected.path = "/tmp/report.txt"
+    selected.is_dir = False
+    frame._get_selected_local_file.return_value = selected
+    frame._transfer_service.submit_upload = MagicMock()
+
+    with patch.object(app.os.path, "getsize", return_value=123):
+        frame._on_upload(None)
+
+    frame._transfer_service.submit_upload.assert_called_once_with(
+        frame._client,
+        "/tmp/report.txt",
+        "/remote/report (1).txt",
+        123,
+        overwrite_existing=False,
+    )
+
+
+def test_resolve_local_conflict_ask_accepts_existing_path(tmp_path, app_module):
+    app, fake_wx = app_module
+    frame = _hydrate_frame(app_module)
+    local_path = tmp_path / "report.txt"
+    local_path.write_text("existing")
+    fake_wx.MessageBox.return_value = fake_wx.YES
+
+    result = frame._resolve_local_transfer_conflict(str(local_path), "report.txt", "download")
+
+    assert result == str(local_path)
+    fake_wx.MessageBox.assert_called_once()
+
+
+def test_resolve_local_conflict_ask_rejects_existing_path(tmp_path, app_module):
+    app, fake_wx = app_module
+    frame = _hydrate_frame(app_module)
+    local_path = tmp_path / "report.txt"
+    local_path.write_text("existing")
+    fake_wx.MessageBox.return_value = fake_wx.OK
+
+    result = frame._resolve_local_transfer_conflict(str(local_path), "report.txt", "download")
+
+    assert result is None
+    frame._announce.assert_called_with("Skipped download; report.txt already exists")
+
+
+def test_unique_local_path_skips_existing_numbered_candidate(tmp_path, app_module):
+    app, _ = app_module
+    original = tmp_path / "report.txt"
+    first = tmp_path / "report (1).txt"
+    original.write_text("existing")
+    first.write_text("existing")
+
+    assert app.MainFrame._unique_local_path(str(original)) == str(tmp_path / "report (2).txt")
+
+
+def test_remote_conflict_helpers_cover_empty_and_ask_paths(app_module):
+    app, fake_wx = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = None
+    assert frame._remote_path_exists("/remote/missing.txt") is False
+
+    frame._client = MagicMock()
+    frame._client.stat.side_effect = [FileNotFoundError, SimpleNamespace(), FileNotFoundError]
+    assert frame._unique_remote_path("/remote/report.txt") == "/remote/report.txt"
+
+    def stat_existing_numbered(path):
+        if path in {"/remote/report.txt", "/remote/report (1).txt"}:
+            return SimpleNamespace()
+        raise FileNotFoundError(path)
+
+    frame._client.stat.side_effect = stat_existing_numbered
+    assert frame._unique_remote_path("/remote/report.txt") == "/remote/report (2).txt"
+
+    frame._client.stat.return_value = SimpleNamespace()
+    frame._client.stat.side_effect = None
+    fake_wx.MessageBox.return_value = fake_wx.YES
+    assert (
+        frame._resolve_remote_transfer_conflict("/remote/report.txt", "report.txt", "upload")
+        == "/remote/report.txt"
+    )
+
+    fake_wx.MessageBox.return_value = fake_wx.OK
+    assert (
+        frame._resolve_remote_transfer_conflict("/remote/report.txt", "report.txt", "upload")
+        is None
+    )
+    frame._announce.assert_called_with("Skipped upload; report.txt already exists")
+
+
 def test_paste_upload_shows_queue(tmp_path, app_module):
     app, _ = app_module
     frame = _hydrate_frame(app_module)
     frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._client.stat.side_effect = FileNotFoundError
     frame._transfer_service.submit_upload = MagicMock()
     file_path = tmp_path / "clip.txt"
     file_path.write_text("clip")
@@ -255,6 +482,24 @@ def test_paste_upload_shows_queue(tmp_path, app_module):
 
     frame._transfer_service.submit_upload.assert_called_once()
     frame._show_transfer_queue.assert_called_once()
+
+
+def test_paste_upload_skip_existing_remote_file(tmp_path, app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame._client = MagicMock(connected=True, cwd="/remote")
+    frame._client.stat.return_value = SimpleNamespace()
+    frame._settings.transfer.overwrite_mode = "skip"
+    frame._transfer_service.submit_upload = MagicMock()
+    file_path = tmp_path / "clip.txt"
+    file_path.write_text("clip")
+    frame._get_clipboard_files = MagicMock(return_value=[str(file_path)])
+
+    frame._paste_upload()
+
+    frame._transfer_service.submit_upload.assert_not_called()
+    frame._show_transfer_queue.assert_not_called()
+    frame._announce.assert_called_with("Skipped upload; clip.txt already exists")
 
 
 def test_delete_remote_updates_status_on_success(app_module):

--- a/tests/test_transfer_persist.py
+++ b/tests/test_transfer_persist.py
@@ -30,6 +30,7 @@ class TestTransferJobToDict:
             protocol="sftp",
             total_bytes=1024,
             transferred_bytes=512,
+            overwrite_existing=True,
             status=TransferStatus.PENDING,
             error=None,
         )
@@ -42,6 +43,7 @@ class TestTransferJobToDict:
             "protocol": "sftp",
             "total_bytes": 1024,
             "transferred_bytes": 512,
+            "overwrite_existing": True,
             "status": "pending",
             "error": "",
         }
@@ -87,6 +89,7 @@ class TestTransferJobFromDict:
             "protocol": "sftp",
             "total_bytes": 2048,
             "transferred_bytes": 0,
+            "overwrite_existing": True,
             "status": "pending",
             "error": "",
         }
@@ -98,6 +101,7 @@ class TestTransferJobFromDict:
         assert job.protocol == "sftp"
         assert job.total_bytes == 2048
         assert job.transferred_bytes == 0
+        assert job.overwrite_existing is True
         assert job.status == TransferStatus.RESTORED
         assert job.error is None
 

--- a/tests/test_transfer_service.py
+++ b/tests/test_transfer_service.py
@@ -145,6 +145,39 @@ class TestSubmitDownload:
         assert job.status == TransferStatus.FAILED
         assert "disk full" in job.error
 
+    def test_fresh_download_fails_before_overwriting_existing_file(self, tmp_path):
+        dest = tmp_path / "file.bin"
+        dest.write_bytes(b"existing")
+        mock_client = MagicMock()
+
+        svc = TransferService(notify_window=None)
+        job = svc.submit_download(mock_client, "/remote/file.bin", str(dest), total_bytes=4)
+
+        _wait_for_terminal(job)
+        assert job.status == TransferStatus.FAILED
+        assert "already exists" in (job.error or "")
+        assert dest.read_bytes() == b"existing"
+        mock_client.download.assert_not_called()
+
+    def test_download_allows_explicit_overwrite(self, tmp_path):
+        dest = tmp_path / "file.bin"
+        dest.write_bytes(b"existing")
+        mock_client = MagicMock()
+        mock_client.download.side_effect = lambda src, fh, callback=None, offset=0: fh.write(b"new")
+
+        svc = TransferService(notify_window=None)
+        job = svc.submit_download(
+            mock_client,
+            "/remote/file.bin",
+            str(dest),
+            total_bytes=3,
+            overwrite_existing=True,
+        )
+
+        _wait_for_terminal(job)
+        assert job.status == TransferStatus.COMPLETE
+        assert dest.read_bytes() == b"new"
+
 
 class TestSubmitUpload:
     def test_enqueues_and_completes_upload(self, tmp_path):
@@ -314,6 +347,27 @@ class TestRecursiveDownload:
 
         assert job.total_bytes == 500
         mock_client.stat.assert_called_once_with("/remote/dir/link.txt")
+
+    def test_recursive_download_fails_before_overwriting_existing_child(self, tmp_path):
+        from portkeydrop.protocols import RemoteFile
+
+        destination = tmp_path / "local"
+        destination.mkdir()
+        existing = destination / "a.txt"
+        existing.write_text("existing")
+        mock_client = MagicMock()
+        mock_client.list_dir.return_value = [
+            RemoteFile(name="a.txt", path="/remote/dir/a.txt", size=10),
+        ]
+
+        svc = TransferService(notify_window=None)
+        job = svc.submit_download(mock_client, "/remote/dir", str(destination), recursive=True)
+
+        _wait_for_terminal(job)
+        assert job.status == TransferStatus.FAILED
+        assert "already exists" in (job.error or "")
+        assert existing.read_text() == "existing"
+        mock_client.download.assert_not_called()
 
 
 class TestRecursiveUpload:


### PR DESCRIPTION
## Summary

- Enforce the existing transfer overwrite setting before downloads, uploads, and clipboard uploads are enqueued.
- Add skip and auto-rename handling for local download conflicts and remote upload conflicts.
- Add a service-level fresh-download guard using exclusive create so direct service callers cannot truncate existing local files unless overwrite was explicitly allowed.
- Persist explicit overwrite intent with queued jobs so approved pending transfers survive queue save/load.

## Scope

This PR addresses the transfer safety group from the review findings. It does not change SCP/WebDAV product claims or broader connection-default handling; those are separate follow-up PR surfaces.

## Verification

- `uv run ruff check src tests`
- `uv run python -m pytest -q --tb=short tests/test_app.py tests/test_transfer_service.py tests/test_queue_during_transfer.py tests/test_retry_failed_transfers.py tests/test_resume_download.py tests/test_transfer_symlink.py tests/test_transfer_persist.py`

## Known Existing Full-Suite Failures

A full local run reported the same unrelated Windows path expectation failures:

- `tests/test_importers_winscp.py::test_detect_ini_path_appdata`
- `tests/test_local_files.py::TestParentLocal::test_parent_of_root`

Full-suite result: `791 passed, 2 failed, 8 warnings`.