### PR TITLE
docs(protocols): align implemented protocol claims

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,17 +1,23 @@
 # Portkey Drop - Product Requirements Document
 
 ## Overview
-Portkey Drop is an accessible file transfer client built for screen reader users. It provides a clean, keyboard-driven interface for connecting to remote servers via FTP, SFTP, FTPS, SCP, and WebDAV. Built with wxPython and Prismatoid for full NVDA/JAWS compatibility.
+Portkey Drop is an accessible file transfer client built for screen reader users. It provides a clean, keyboard-driven interface for connecting to remote servers via SFTP, FTP, and FTPS. SCP and WebDAV are planned protocol targets. Built with wxPython and Prismatoid for full NVDA/JAWS compatibility.
 
 ## Why This Exists
 Existing file transfer clients (FileZilla, WinSCP, Cyberduck) rely heavily on visual cues (drag-and-drop, tree views with icons) that don't translate well to assistive technology. Portkey Drop uses a dual-pane layout with properly labeled standard ListCtrl panes ("Local Files" / "Remote Files") that screen readers like NVDA and JAWS handle naturally. Each pane is a standard list control with SetName(), so screen readers announce which pane has focus. Every action is keyboard-accessible and every state change is announced.
 
-## Supported Protocols
+## Protocols
+
+Implemented:
+
 1. **SFTP** (SSH File Transfer Protocol) - Primary, most secure, most common
 2. **FTP** (File Transfer Protocol) - Legacy support, still widely used
 3. **FTPS** (FTP over SSL/TLS) - Encrypted FTP
-4. **SCP** (Secure Copy Protocol) - Fast SSH-based transfers
-5. **WebDAV** (Web Distributed Authoring) - HTTP-based, used by cloud services
+
+Planned:
+
+1. **SCP** (Secure Copy Protocol) - Fast SSH-based transfers
+2. **WebDAV** (Web Distributed Authoring) - HTTP-based, used by cloud services
 
 ## Core Features
 
@@ -58,7 +64,7 @@ Existing file transfer clients (FileZilla, WinSCP, Cyberduck) rely heavily on vi
 
 ### Connection Defaults
 - Default protocol: SFTP (most secure)
-- Default port: 22 (SFTP), 21 (FTP), 990 (FTPS), 443 (WebDAV)
+- Default port: 22 (SFTP), 21 (FTP), 990 (FTPS)
 - Connection timeout: 30 seconds
 - Keepalive interval: 60 seconds
 - Max retries: 3
@@ -83,10 +89,10 @@ Existing file transfer clients (FileZilla, WinSCP, Cyberduck) rely heavily on vi
 ## Architecture
 - **UI Layer**: wxPython + Prismatoid (screen reader announcements)
 - **Protocol Layer**: Abstract `TransferClient` interface per protocol
-  - `paramiko` for SFTP/SCP
+  - `asyncssh` for SFTP
   - `ftplib` (stdlib) for FTP
   - `ftplib` with SSL context for FTPS
-  - `requests` + `webdavlib` for WebDAV
+  - Planned: SCP and WebDAV clients
 - **Settings**: JSON config at `~/.portkeydrop/settings.json`
 - **Site Manager**: JSON at `~/.portkeydrop/sites.json` (passwords encrypted)
 - **Transfer Queue**: Threaded background transfers with progress callbacks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portkey Drop
 
-A keyboard-driven file transfer client supporting FTP, SFTP, FTPS, SCP, and WebDAV. Dual-pane interface with full keyboard navigation and screen reader compatibility (NVDA, JAWS).
+A keyboard-driven file transfer client supporting SFTP, FTP, and FTPS. Dual-pane interface with full keyboard navigation and screen reader compatibility (NVDA, JAWS).
 
 ## Layout
 
@@ -32,9 +32,14 @@ Each pane is a labeled standard list control, so screen readers announce "Local 
 
 ## Protocols
 
+Implemented:
+
 - **SFTP** (default) — SSH-based, most secure
 - **FTP** — Legacy support
 - **FTPS** — FTP over SSL/TLS
+
+Planned:
+
 - **SCP** — Fast SSH transfers (planned)
 - **WebDAV** — HTTP-based, cloud service compatible (planned)
 

--- a/docs/index.template.html
+++ b/docs/index.template.html
@@ -106,7 +106,7 @@
 
     <header>
         <h1>🗝️ PortkeyDrop</h1>
-        <p>A keyboard-driven, screen-reader-friendly file transfer client for FTP, SFTP, FTPS, SCP, and WebDAV.</p>
+        <p>A keyboard-driven, screen-reader-friendly file transfer client for SFTP, FTP, and FTPS.</p>
     </header>
 
     <main>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "portkeydrop"
 version = "0.3.0"
-description = "A keyboard-driven file transfer client for FTP, SFTP, FTPS, SCP, and WebDAV"
+description = "A keyboard-driven file transfer client for SFTP, FTP, and FTPS"
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "asyncssh>=2.14",


### PR DESCRIPTION
## Summary

- Update README, PRD, package metadata, and docs landing copy to state that SFTP, FTP, and FTPS are currently implemented.
- Keep SCP and WebDAV listed as planned protocol targets rather than current support.
- Refresh PRD protocol architecture notes to match the current asyncssh/ftplib implementation.

## Scope

This PR addresses the protocol-claim alignment review finding only. It does not implement SCP/WebDAV support.

## Verification

- `uv run ruff check .`
- Searched README, PRD, pyproject metadata, and docs template for stale current-support claims around SCP/WebDAV.