### PR TITLE
fix(connections): apply configured defaults consistently

### DIFF
--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -509,8 +509,8 @@ class MainFrame(wx.Frame):
             port=int(port_str) if port_str else 0,
             username=self.tb_username.GetValue().strip(),
             password=self.tb_password.GetValue(),
-            host_key_policy=self._host_key_policy(),
         )
+        self._apply_connection_defaults(info)
         self._do_connect(info)
 
     def _on_quick_connect(self, event: wx.CommandEvent) -> None:
@@ -518,6 +518,7 @@ class MainFrame(wx.Frame):
         info = None
         if dlg.ShowModal() == wx.ID_OK:
             info = dlg.get_connection_info()
+            self._apply_connection_defaults(info)
         dlg.Destroy()
         if info:
             self._do_connect(info)
@@ -528,7 +529,7 @@ class MainFrame(wx.Frame):
         info = None
         if result == wx.ID_OK and dlg.connect_requested and dlg.selected_site:
             info = dlg.selected_site.to_connection_info()
-            info.host_key_policy = self._host_key_policy()
+            self._apply_connection_defaults(info)
         dlg.Destroy()
         if info:
             self._do_connect(info)
@@ -639,6 +640,13 @@ class MainFrame(wx.Frame):
         }
         setting = getattr(self._settings.connection, "verify_host_keys", "ask")
         return mapping.get(setting, HostKeyPolicy.PROMPT)
+
+    def _apply_connection_defaults(self, info: ConnectionInfo) -> None:
+        """Apply app-level connection defaults to a connection request."""
+        defaults = getattr(self._settings, "connection", None)
+        info.timeout = max(1, int(getattr(defaults, "timeout", info.timeout)))
+        info.passive_mode = bool(getattr(defaults, "passive_mode", info.passive_mode))
+        info.host_key_policy = self._host_key_policy()
 
     def _do_connect(self, info: ConnectionInfo) -> None:
         if not info.host:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,6 +81,9 @@ def _hydrate_frame(module):
     frame._last_failed_transfer = None
     frame._retry_last_failed_item = MagicMock()
     frame._toolbar_panel = MagicMock()
+    frame._settings = SimpleNamespace(
+        connection=SimpleNamespace(timeout=45, passive_mode=False, verify_host_keys="never")
+    )
     return frame
 
 
@@ -411,6 +414,62 @@ def test_import_connections_skips_duplicates(app_module):
     message = fake_wx.MessageBox.call_args.args[0]
     assert "Imported 0 connections" in message
     assert "Skipped 1 duplicate" in message
+
+
+def test_apply_connection_defaults_sets_timeout_passive_and_host_key_policy(app_module):
+    app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    info = app.ConnectionInfo(protocol=app.Protocol.SFTP, host="example.com")
+
+    frame._apply_connection_defaults(info)
+
+    assert info.timeout == 45
+    assert info.passive_mode is False
+    assert info.host_key_policy == app.HostKeyPolicy.STRICT
+
+
+def test_quick_connect_applies_connection_defaults(app_module):
+    app, fake_wx = app_module
+    frame = _hydrate_frame(app_module)
+    frame._do_connect = MagicMock()
+    info = app.ConnectionInfo(protocol=app.Protocol.FTP, host="example.com", username="alice")
+    dialog = MagicMock(
+        ShowModal=MagicMock(return_value=fake_wx.ID_OK),
+        get_connection_info=MagicMock(return_value=info),
+        Destroy=MagicMock(),
+    )
+
+    with patch.object(app, "QuickConnectDialog", return_value=dialog):
+        frame._on_quick_connect(None)
+
+    frame._do_connect.assert_called_once_with(info)
+    assert info.timeout == 45
+    assert info.passive_mode is False
+    assert info.host_key_policy == app.HostKeyPolicy.STRICT
+
+
+def test_site_manager_connect_applies_connection_defaults(app_module):
+    app, fake_wx = app_module
+    frame = _hydrate_frame(app_module)
+    frame._do_connect = MagicMock()
+    site = MagicMock()
+    info = app.ConnectionInfo(protocol=app.Protocol.FTPS, host="example.com", username="alice")
+    site.to_connection_info.return_value = info
+    dialog = MagicMock(
+        ShowModal=MagicMock(return_value=fake_wx.ID_OK),
+        connect_requested=True,
+        selected_site=site,
+        Destroy=MagicMock(),
+    )
+    frame._site_manager = MagicMock()
+
+    with patch.object(app, "SiteManagerDialog", return_value=dialog):
+        frame._on_site_manager(None)
+
+    frame._do_connect.assert_called_once_with(info)
+    assert info.timeout == 45
+    assert info.passive_mode is False
+    assert info.host_key_policy == app.HostKeyPolicy.STRICT
 
 
 def test_on_transfer_update_reports_latest_status(app_module):


### PR DESCRIPTION
## Summary

- Add one app-level helper to apply configured connection defaults to `ConnectionInfo` requests.
- Route toolbar, Quick Connect, and Site Manager connection flows through the same timeout, passive-mode, and host-key-policy defaults.
- Add regression coverage for default propagation through direct helper use, Quick Connect, and Site Manager connects.

## Scope

This PR addresses the connection-default propagation review concern only. It does not add per-site UI for editing timeout/passive/host-key settings.

## Verification

- `uv run ruff check src tests`
- `uv run python -m pytest -q --tb=short tests/test_app.py tests/test_sites.py tests/test_protocols.py tests/test_settings.py tests/test_settings_dialog_a11y.py tests/test_host_key_policy.py tests/test_host_key_verification.py`

## Known Existing Full-Suite Failures

A full local run reported the same unrelated Windows path expectation failures:

- `tests/test_importers_winscp.py::test_detect_ini_path_appdata`
- `tests/test_local_files.py::TestParentLocal::test_parent_of_root`

Full-suite result: `787 passed, 2 failed, 8 warnings`.