### PR TITLE
test(windows): normalize path expectations

### DIFF
--- a/tests/test_importers_winscp.py
+++ b/tests/test_importers_winscp.py
@@ -168,7 +168,7 @@ def test_detect_ini_path_appdata(monkeypatch):
     monkeypatch.setenv("APPDATA", "/fake/appdata")
     from portkeydrop.importers.winscp import detect_ini_path
 
-    assert str(detect_ini_path()) == "/fake/appdata/WinSCP.ini"
+    assert detect_ini_path() == Path("/fake/appdata") / "WinSCP.ini"
 
 
 def test_detect_ini_path_no_appdata(monkeypatch):

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -94,8 +95,9 @@ class TestParentLocal:
         assert result == tmp_path.resolve()
 
     def test_parent_of_root(self):
-        result = parent_local("/")
-        assert str(result) == "/"
+        root = Path(Path.cwd().anchor)
+        result = parent_local(root)
+        assert result == root
 
 
 class TestDeleteLocal:


### PR DESCRIPTION
## Summary
- Compare WinSCP APPDATA detection as a `Path` instead of a hard-coded POSIX string.
- Make the local root-parent test use the current platform root instead of assuming `/`.

## Verification
- `uv run python -m pytest -q --tb=short tests/test_importers_winscp.py::test_detect_ini_path_appdata tests/test_local_files.py::TestParentLocal::test_parent_of_root`
- `uv run ruff format tests/test_importers_winscp.py tests/test_local_files.py`
- `uv run ruff check src tests`
- `uv run python -m pytest -q -n 0 --tb=short` (`786 passed, 7 warnings`)