### PR TITLE
fix(a11y): add macOS listbox fallback for VoiceOver

### DIFF
--- a/src/portkeydrop/accessible_list.py
+++ b/src/portkeydrop/accessible_list.py
@@ -1,0 +1,240 @@
+"""Cross-platform report-list helpers with a macOS VoiceOver fallback."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+import importlib
+from typing import Any
+
+
+RowFormatter = Callable[[Sequence[str], Sequence[str]], str]
+
+
+def _wx() -> Any:
+    return importlib.import_module("wx")
+
+
+def _is_macos() -> bool:
+    wx = _wx()
+    return getattr(wx, "Platform", "") == "__WXMAC__"
+
+
+def file_row_text(columns: Sequence[str], _headers: Sequence[str]) -> str:
+    name = columns[0] if len(columns) > 0 else ""
+    size = columns[1] if len(columns) > 1 else ""
+    kind = columns[2] if len(columns) > 2 else ""
+    modified = columns[3] if len(columns) > 3 else ""
+    permissions = columns[4] if len(columns) > 4 else ""
+
+    parts = [kind or "Item", name]
+    if size:
+        parts.append(f"size {size}")
+    if modified:
+        parts.append(f"modified {modified}")
+    if permissions:
+        parts.append(f"permissions {permissions}")
+    return ", ".join(parts)
+
+
+def report_row_text(columns: Sequence[str], headers: Sequence[str]) -> str:
+    parts = []
+    for header, value in zip(headers, columns, strict=False):
+        if value:
+            parts.append(f"{header} {value}")
+    return ", ".join(parts)
+
+
+class AccessibleReportList:
+    """A ListCtrl-compatible wrapper that uses ListBox on macOS.
+
+    wx.ListCtrl works well enough for NVDA/JAWS in report mode, but VoiceOver
+    often fails to expose useful row/column details. On macOS, a single-column
+    ListBox with complete row text gives VoiceOver a simpler accessibility tree.
+    """
+
+    def __init__(
+        self,
+        parent: Any,
+        *,
+        style: int = 0,
+        row_formatter: RowFormatter | None = None,
+    ) -> None:
+        self._headers: list[str] = []
+        self._rows: list[list[str]] = []
+        self._row_formatter = row_formatter or report_row_text
+        self._wx = _wx()
+        self._focused = self._wx.NOT_FOUND
+        self._is_listbox = _is_macos()
+
+        if self._is_listbox:
+            listbox_style = getattr(self._wx, "LB_SINGLE", 0)
+            self._ctrl = self._wx.ListBox(parent, style=listbox_style)
+        else:
+            self._ctrl = self._wx.ListCtrl(parent, style=style)
+            for name in (
+                "Bind",
+                "DeleteAllItems",
+                "DeleteItem",
+                "Focus",
+                "GetFirstSelected",
+                "GetFocusedItem",
+                "GetItemCount",
+                "GetItemText",
+                "InsertColumn",
+                "InsertItem",
+                "Select",
+                "SetFocus",
+                "SetItem",
+            ):
+                setattr(self, name, getattr(self._ctrl, name))
+
+    @property
+    def window(self) -> Any:
+        return self._ctrl
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._ctrl, name)
+
+    def InsertColumn(self, col: int, heading: str, width: int = -1) -> None:
+        if col >= len(self._headers):
+            self._headers.extend([""] * (col - len(self._headers) + 1))
+        self._headers[col] = heading
+        if not self._is_listbox:
+            self._ctrl.InsertColumn(col, heading, width=width)
+
+    def InsertItem(self, index: int, label: str) -> int:
+        if not self._is_listbox:
+            return self._ctrl.InsertItem(index, label)
+
+        row = ["" for _ in self._headers]
+        if not row:
+            row = [""]
+        row[0] = label
+        index = max(0, min(index, len(self._rows)))
+        self._rows.insert(index, row)
+        self._ctrl.InsertItems([self._format_row(index)], index)
+        return index
+
+    def SetItem(self, row: int, col: int, value: str) -> None:
+        if not self._is_listbox:
+            self._ctrl.SetItem(row, col, value)
+            return
+
+        previous_count = len(self._rows)
+        self._ensure_cell(row, col)
+        self._rows[row][col] = value
+        if row >= previous_count:
+            new_items = [self._format_row(i) for i in range(previous_count, len(self._rows))]
+            self._ctrl.InsertItems(new_items, previous_count)
+        else:
+            self._ctrl.SetString(row, self._format_row(row))
+
+    def GetItemText(self, row: int, col: int = 0) -> str:
+        if not self._is_listbox:
+            return self._ctrl.GetItemText(row, col)
+        if 0 <= row < len(self._rows) and 0 <= col < len(self._rows[row]):
+            return self._rows[row][col]
+        return ""
+
+    def GetItemCount(self) -> int:
+        if not self._is_listbox:
+            return self._ctrl.GetItemCount()
+        return len(self._rows)
+
+    def DeleteAllItems(self) -> None:
+        self._rows.clear()
+        self._focused = self._wx.NOT_FOUND
+        if self._is_listbox:
+            self._ctrl.Clear()
+        else:
+            self._ctrl.DeleteAllItems()
+
+    def DeleteItem(self, row: int) -> None:
+        if not self._is_listbox:
+            self._ctrl.DeleteItem(row)
+            return
+        if 0 <= row < len(self._rows):
+            del self._rows[row]
+            self._ctrl.Delete(row)
+            if self._focused >= len(self._rows):
+                self._focused = self._wx.NOT_FOUND
+
+    def GetFirstSelected(self) -> int:
+        if not self._is_listbox:
+            return self._ctrl.GetFirstSelected()
+        selection = self._ctrl.GetSelection()
+        if 0 <= selection < len(self._rows):
+            return selection
+        return self._wx.NOT_FOUND
+
+    def GetFocusedItem(self) -> int:
+        if not self._is_listbox:
+            return self._ctrl.GetFocusedItem()
+        selected = self.GetFirstSelected()
+        if selected != self._wx.NOT_FOUND:
+            return selected
+        if 0 <= self._focused < len(self._rows):
+            return self._focused
+        return self._wx.NOT_FOUND
+
+    def Select(self, row: int, on: bool = True) -> None:
+        if not self._is_listbox:
+            self._ctrl.Select(row, on)
+            return
+        if on and 0 <= row < len(self._rows):
+            self._ctrl.SetSelection(row)
+            self._focused = row
+        elif not on and self.GetFirstSelected() == row:
+            self._ctrl.SetSelection(self._wx.NOT_FOUND)
+
+    def Focus(self, row: int) -> None:
+        if not self._is_listbox:
+            self._ctrl.Focus(row)
+            return
+        if 0 <= row < len(self._rows):
+            self._focused = row
+            self._ctrl.SetSelection(row)
+
+    def Bind(self, event: Any, handler: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        if self._is_listbox and event is self._wx.EVT_LIST_ITEM_ACTIVATED:
+            self._bind_listbox_activation(handler)
+            return
+        if self._is_listbox and event is self._wx.EVT_KEY_DOWN:
+            self._ctrl.Bind(self._wx.EVT_CHAR_HOOK, handler, *args, **kwargs)
+            return
+        self._ctrl.Bind(event, handler, *args, **kwargs)
+
+    def _bind_listbox_activation(self, handler: Callable[..., Any]) -> None:
+        if hasattr(self._wx, "EVT_LISTBOX_DCLICK"):
+            self._ctrl.Bind(self._wx.EVT_LISTBOX_DCLICK, handler)
+
+        def on_char_hook(event: Any) -> None:
+            key = event.GetKeyCode()
+            enter_keys = {
+                getattr(self._wx, "WXK_RETURN", 13),
+                getattr(self._wx, "WXK_NUMPAD_ENTER", 13),
+            }
+            if key in enter_keys:
+                handler(event)
+                return
+            event.Skip()
+
+        self._ctrl.Bind(self._wx.EVT_CHAR_HOOK, on_char_hook)
+
+    def _format_row(self, row: int) -> str:
+        return self._row_formatter(self._rows[row], self._headers)
+
+    def _ensure_cell(self, row: int, col: int) -> None:
+        while row >= len(self._rows):
+            self._rows.append(["" for _ in self._headers])
+        if col >= len(self._rows[row]):
+            self._rows[row].extend([""] * (col - len(self._rows[row]) + 1))
+
+
+def create_report_list(
+    parent: Any,
+    *,
+    style: int = 0,
+    row_formatter: RowFormatter | None = None,
+) -> AccessibleReportList:
+    return AccessibleReportList(parent, style=style, row_formatter=row_formatter)

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePosixPath
 import wx
 
 from portkeydrop import __version__
+from portkeydrop.accessible_list import AccessibleReportList, create_report_list, file_row_text
 from portkeydrop.dialogs.properties import PropertiesDialog
 from portkeydrop.dialogs.quick_connect import QuickConnectDialog
 from portkeydrop.dialogs.settings import SettingsDialog
@@ -307,13 +308,17 @@ class MainFrame(wx.Frame):
         local_list_label = wx.StaticText(local_panel, label="Local:")
         local_sizer.Add(local_list_label, 0, wx.LEFT, 4)
 
-        self.local_file_list = wx.ListCtrl(local_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+        self.local_file_list = create_report_list(
+            local_panel,
+            style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
+            row_formatter=file_row_text,
+        )
         self.local_file_list.InsertColumn(0, "Name", width=200)
         self.local_file_list.InsertColumn(1, "Size", width=80)
         self.local_file_list.InsertColumn(2, "Type", width=70)
         self.local_file_list.InsertColumn(3, "Modified", width=130)
         self.local_file_list.InsertColumn(4, "Permissions", width=100)
-        local_sizer.Add(self.local_file_list, 1, wx.EXPAND)
+        local_sizer.Add(self.local_file_list.window, 1, wx.EXPAND)
         local_panel.SetSizer(local_sizer)
 
         # --- Remote pane (right) ---
@@ -332,13 +337,17 @@ class MainFrame(wx.Frame):
         remote_list_label = wx.StaticText(remote_panel, label="Remote:")
         remote_sizer.Add(remote_list_label, 0, wx.LEFT, 4)
 
-        self.remote_file_list = wx.ListCtrl(remote_panel, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+        self.remote_file_list = create_report_list(
+            remote_panel,
+            style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
+            row_formatter=file_row_text,
+        )
         self.remote_file_list.InsertColumn(0, "Name", width=200)
         self.remote_file_list.InsertColumn(1, "Size", width=80)
         self.remote_file_list.InsertColumn(2, "Type", width=70)
         self.remote_file_list.InsertColumn(3, "Modified", width=130)
         self.remote_file_list.InsertColumn(4, "Permissions", width=100)
-        remote_sizer.Add(self.remote_file_list, 1, wx.EXPAND)
+        remote_sizer.Add(self.remote_file_list.window, 1, wx.EXPAND)
         self.remote_panel = remote_panel
         remote_panel.SetSizer(remote_sizer)
 
@@ -405,20 +414,22 @@ class MainFrame(wx.Frame):
 
     def _is_local_focused(self) -> bool:
         """Return True if the local pane currently has focus."""
-        focused = self.FindFocus()
-        return focused is self.local_file_list
+        return self._is_list_focused(self.local_file_list)
 
     def _is_remote_focused(self) -> bool:
         """Return True if the remote pane currently has focus."""
-        focused = self.FindFocus()
-        return focused is self.remote_file_list
+        return self._is_list_focused(self.remote_file_list)
 
-    def _get_focused_file_list(self) -> wx.ListCtrl | None:
-        """Return whichever file list has focus, or None."""
+    def _is_list_focused(self, file_list: AccessibleReportList) -> bool:
         focused = self.FindFocus()
-        if focused is self.local_file_list:
+        window = getattr(file_list, "window", file_list)
+        return focused is file_list or focused is window
+
+    def _get_focused_file_list(self) -> AccessibleReportList | None:
+        """Return whichever file list has focus, or None."""
+        if self._is_list_focused(self.local_file_list):
             return self.local_file_list
-        if focused is self.remote_file_list:
+        if self._is_list_focused(self.remote_file_list):
             return self.remote_file_list
         return None
 
@@ -768,16 +779,15 @@ class MainFrame(wx.Frame):
             self._refresh_remote_files()
 
     def _on_switch_pane_focus(self, event: wx.CommandEvent) -> None:
-        focused = self.FindFocus()
         if self._activity_log_visible:
-            if focused is self.local_file_list:
+            if self._is_local_focused():
                 self.remote_file_list.SetFocus()
-            elif focused is self.remote_file_list:
+            elif self._is_remote_focused():
                 self.activity_log.SetFocus()
             else:
                 self.local_file_list.SetFocus()
         else:
-            if focused is self.local_file_list:
+            if self._is_local_focused():
                 self.remote_file_list.SetFocus()
             else:
                 self.local_file_list.SetFocus()
@@ -839,7 +849,7 @@ class MainFrame(wx.Frame):
         threading.Thread(target=_worker, daemon=True).start()
 
     def _on_remote_files_loaded(self, files: list[RemoteFile], cwd: str) -> None:
-        restore_focus = self.FindFocus() is self.remote_file_list
+        restore_focus = self._is_remote_focused()
         self._apply_sort(files)
         # Insert ".." entry at the top to navigate to parent
         if cwd != "/":
@@ -874,7 +884,7 @@ class MainFrame(wx.Frame):
         wx.MessageBox(msg, "Error", wx.OK | wx.ICON_ERROR, self)
 
     def _refresh_local_files(self) -> None:
-        restore_focus = self.FindFocus() is self.local_file_list
+        restore_focus = self._is_local_focused()
         try:
             self._local_files = list_local_dir(self._local_cwd)
             self._apply_sort(self._local_files)
@@ -932,7 +942,7 @@ class MainFrame(wx.Frame):
         key_fn = key_map.get(self._settings.display.sort_by, key_map["name"])
         files.sort(key=key_fn, reverse=not self._settings.display.sort_ascending)
 
-    def _populate_file_list(self, list_ctrl: wx.ListCtrl, files: list[RemoteFile]) -> None:
+    def _populate_file_list(self, list_ctrl: AccessibleReportList, files: list[RemoteFile]) -> None:
         list_ctrl.DeleteAllItems()
         for f in files:
             idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), f.name)
@@ -992,7 +1002,7 @@ class MainFrame(wx.Frame):
     # --- Selection helpers ---
 
     def _get_selected_file_from_list(
-        self, list_ctrl: wx.ListCtrl, files: list[RemoteFile], filter_text: str
+        self, list_ctrl: AccessibleReportList, files: list[RemoteFile], filter_text: str
     ) -> RemoteFile | None:
         idx = list_ctrl.GetFirstSelected()
         if idx == wx.NOT_FOUND:

--- a/src/portkeydrop/dialogs/transfer.py
+++ b/src/portkeydrop/dialogs/transfer.py
@@ -65,6 +65,8 @@ def create_transfer_dialog(parent, transfer_service: TransferService, log_callba
     import wx
     from pathlib import PurePosixPath
 
+    from portkeydrop.accessible_list import create_report_list
+
     class TransferDialog(wx.Dialog):
         """Disposable observer over the :class:`TransferService` job list."""
 
@@ -97,13 +99,13 @@ def create_transfer_dialog(parent, transfer_service: TransferService, log_callba
             # StaticText label immediately before the list so NVDA resolves
             # "Transfer Queue" as the accessible name via HWND sibling order.
             wx.StaticText(self, label="Transfer Queue:")
-            self.transfer_list = wx.ListCtrl(self, style=wx.LC_REPORT)
+            self.transfer_list = create_report_list(self, style=wx.LC_REPORT)
             self.transfer_list.InsertColumn(0, "File", width=200)
             self.transfer_list.InsertColumn(1, "Direction", width=80)
             self.transfer_list.InsertColumn(2, "Progress", width=80)
             self.transfer_list.InsertColumn(3, "Transferred", width=130)
             self.transfer_list.InsertColumn(4, "Status", width=100)
-            sizer.Add(self.transfer_list, 1, wx.EXPAND | wx.ALL, 8)
+            sizer.Add(self.transfer_list.window, 1, wx.EXPAND | wx.ALL, 8)
 
             btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
             # Full label gives screen reader users context without needing to read

--- a/tests/test_accessible_list.py
+++ b/tests/test_accessible_list.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests._wx_stub import load_module_with_fake_wx
+
+
+class FakeListBox:
+    def __init__(self, *_args, **_kwargs):
+        self.items: list[str] = []
+        self.selection = -1
+        self.Bind = MagicMock()
+        self.SetFocus = MagicMock()
+
+    def InsertItems(self, items, pos):
+        for offset, item in enumerate(items):
+            self.items.insert(pos + offset, item)
+
+    def SetString(self, index, value):
+        self.items[index] = value
+
+    def GetSelection(self):
+        return self.selection
+
+    def SetSelection(self, index):
+        self.selection = index
+
+    def Clear(self):
+        self.items.clear()
+        self.selection = -1
+
+    def Delete(self, index):
+        del self.items[index]
+
+
+class FakeKeyEvent:
+    def __init__(self, key_code):
+        self.key_code = key_code
+        self.skipped = False
+
+    def GetKeyCode(self):
+        return self.key_code
+
+    def Skip(self):
+        self.skipped = True
+
+
+def test_macos_report_list_uses_listbox_with_complete_row_text(monkeypatch):
+    module, fake_wx = load_module_with_fake_wx("portkeydrop.accessible_list", monkeypatch)
+    fake_wx.Platform = "__WXMAC__"
+    fake_wx.WXK_RETURN = 13
+    fake_wx.WXK_NUMPAD_ENTER = 370
+    fake_wx.EVT_LISTBOX_DCLICK = object()
+
+    listbox = FakeListBox()
+    fake_wx.ListBox = MagicMock(return_value=listbox)
+
+    report = module.create_report_list(
+        MagicMock(),
+        style=fake_wx.LC_REPORT | fake_wx.LC_SINGLE_SEL,
+        row_formatter=module.file_row_text,
+    )
+    report.InsertColumn(0, "Name", width=200)
+    report.InsertColumn(1, "Size", width=80)
+    report.InsertColumn(2, "Type", width=70)
+    report.InsertColumn(3, "Modified", width=130)
+    report.InsertColumn(4, "Permissions", width=100)
+
+    row = report.InsertItem(0, "archive.zip")
+    report.SetItem(row, 1, "42 MB")
+    report.SetItem(row, 2, "File")
+    report.SetItem(row, 3, "2026-05-02 10:00")
+    report.SetItem(row, 4, "rw-r--r--")
+
+    assert report.window is listbox
+    assert listbox.items == [
+        "File, archive.zip, size 42 MB, modified 2026-05-02 10:00, permissions rw-r--r--"
+    ]
+    assert report.GetItemText(0, 0) == "archive.zip"
+    assert report.GetItemText(0, 3) == "2026-05-02 10:00"
+
+
+def test_report_list_passes_through_to_listctrl_off_macos(monkeypatch):
+    module, fake_wx = load_module_with_fake_wx("portkeydrop.accessible_list", monkeypatch)
+    fake_wx.Platform = "__WXMSW__"
+
+    listctrl = MagicMock(name="listctrl")
+    listctrl.InsertItem.return_value = 4
+    listctrl.GetItemText.return_value = "cell"
+    listctrl.GetItemCount.return_value = 3
+    listctrl.GetFirstSelected.return_value = 2
+    listctrl.GetFocusedItem.return_value = 1
+    listctrl.custom_attr = "forwarded"
+    fake_wx.ListCtrl = MagicMock(return_value=listctrl)
+
+    report = module.create_report_list(MagicMock(), style=fake_wx.LC_REPORT)
+    assert report.window is listctrl
+
+    report.InsertColumn(0, "Name", width=200)
+    assert report.InsertItem(1, "file.txt") == 4
+    report.SetItem(4, 1, "42 MB")
+    assert report.GetItemText(4, 1) == "cell"
+    assert report.GetItemCount() == 3
+    report.DeleteAllItems()
+    report.DeleteItem(2)
+    assert report.GetFirstSelected() == 2
+    assert report.GetFocusedItem() == 1
+    report.Select(2, False)
+    report.Focus(1)
+    report.Bind(fake_wx.EVT_CONTEXT_MENU, MagicMock())
+    report.SetFocus()
+    assert report.custom_attr == "forwarded"
+
+    listctrl.InsertColumn.assert_called_once_with(0, "Name", width=200)
+    listctrl.SetItem.assert_called_once_with(4, 1, "42 MB")
+    listctrl.DeleteAllItems.assert_called_once_with()
+    listctrl.DeleteItem.assert_called_once_with(2)
+    listctrl.Select.assert_called_once_with(2, False)
+    listctrl.Focus.assert_called_once_with(1)
+    listctrl.Bind.assert_called_once()
+    listctrl.SetFocus.assert_called_once_with()
+
+
+def test_macos_report_list_preserves_selection_api(monkeypatch):
+    module, fake_wx = load_module_with_fake_wx("portkeydrop.accessible_list", monkeypatch)
+    fake_wx.Platform = "__WXMAC__"
+    fake_wx.EVT_LISTBOX_DCLICK = object()
+
+    listbox = FakeListBox()
+    fake_wx.ListBox = MagicMock(return_value=listbox)
+
+    report = module.create_report_list(MagicMock(), style=fake_wx.LC_REPORT)
+    report.InsertColumn(0, "File")
+    report.InsertItem(0, "a.txt")
+    report.InsertItem(1, "b.txt")
+
+    report.Select(1)
+    assert report.GetFirstSelected() == 1
+    assert report.GetFocusedItem() == 1
+
+    report.DeleteItem(1)
+    assert report.GetItemCount() == 1
+    assert report.GetFocusedItem() == -1
+
+
+def test_macos_report_list_handles_empty_rows_and_out_of_range_cells(monkeypatch):
+    module, fake_wx = load_module_with_fake_wx("portkeydrop.accessible_list", monkeypatch)
+    fake_wx.Platform = "__WXMAC__"
+
+    listbox = FakeListBox()
+    fake_wx.ListBox = MagicMock(return_value=listbox)
+
+    report = module.create_report_list(MagicMock(), style=fake_wx.LC_REPORT)
+    row = report.InsertItem(5, "lonely.txt")
+
+    assert row == 0
+    assert listbox.items == [""]
+    assert report.GetItemText(99, 0) == ""
+    assert report.GetItemText(0, 99) == ""
+
+    report.SetItem(1, 2, "Directory")
+    assert report.GetItemCount() == 2
+    assert report.GetItemText(1, 2) == "Directory"
+
+    report.Focus(1)
+    assert report.GetFocusedItem() == 1
+    report.Select(1, False)
+    assert report.GetFirstSelected() == -1
+    assert report.GetFocusedItem() == 1
+    report.DeleteAllItems()
+    assert report.GetItemCount() == 0
+    assert report.GetFocusedItem() == -1
+
+
+def test_macos_report_list_activation_and_key_bindings(monkeypatch):
+    module, fake_wx = load_module_with_fake_wx("portkeydrop.accessible_list", monkeypatch)
+    fake_wx.Platform = "__WXMAC__"
+    fake_wx.WXK_RETURN = 13
+    fake_wx.WXK_NUMPAD_ENTER = 370
+    fake_wx.EVT_LISTBOX_DCLICK = object()
+
+    listbox = FakeListBox()
+    fake_wx.ListBox = MagicMock(return_value=listbox)
+    handler = MagicMock()
+
+    report = module.create_report_list(MagicMock(), style=fake_wx.LC_REPORT)
+    report.InsertColumn(0, "File")
+    report.InsertItem(0, "a.txt")
+    report.Bind(fake_wx.EVT_LIST_ITEM_ACTIVATED, handler)
+
+    assert listbox.Bind.call_count == 2
+    double_click_event, double_click_handler = listbox.Bind.call_args_list[0].args
+    assert double_click_event is fake_wx.EVT_LISTBOX_DCLICK
+    assert double_click_handler is handler
+
+    char_event, char_handler = listbox.Bind.call_args_list[1].args
+    assert char_event is fake_wx.EVT_CHAR_HOOK
+
+    enter = FakeKeyEvent(13)
+    char_handler(enter)
+    handler.assert_called_once_with(enter)
+    assert not enter.skipped
+
+    other = FakeKeyEvent(65)
+    char_handler(other)
+    assert other.skipped
+
+    key_handler = MagicMock()
+    report.Bind(fake_wx.EVT_KEY_DOWN, key_handler)
+    assert listbox.Bind.call_args.args == (fake_wx.EVT_CHAR_HOOK, key_handler)
+
+    context_handler = MagicMock()
+    report.Bind(fake_wx.EVT_CONTEXT_MENU, context_handler)
+    assert listbox.Bind.call_args.args == (fake_wx.EVT_CONTEXT_MENU, context_handler)


### PR DESCRIPTION
## Summary
- Add a cross-platform report-list adapter that keeps wx.ListCtrl on non-macOS platforms.
- Use wx.ListBox with complete row text on macOS so VoiceOver gets a simpler, readable list experience.
- Wire the adapter into the local/remote file panes and transfer queue.
- Add tests for macOS row text and selection behavior.

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m pytest -q -n 0 --tb=short

## Notes
- Real macOS + VoiceOver smoke testing is still recommended because this targets platform accessibility tree behavior.
