### PR TITLE
ci(build): add macOS release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,43 @@ jobs:
             dist/PortkeyDrop_Setup_*.exe
             dist/PortkeyDrop_Portable_*.zip
 
+  build-macos:
+    name: macOS
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.is_nightly == 'true' && 'dev' || github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --only-binary wxPython wxPython
+          pip install -e .[dev] pyinstaller pillow
+
+      - name: Build
+        timeout-minutes: 30
+        run: |
+          python installer/build.py --skip-installer --tag "${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}"
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: macos
+          path: |
+            dist/PortkeyDrop_macOS_*.zip
+
   release:
     name: Release
-    needs: [prepare, build-windows]
-    if: always() && needs.prepare.outputs.should_build == 'true' && needs.build-windows.result == 'success'
+    needs: [prepare, build-windows, build-macos]
+    if: always() && needs.prepare.outputs.should_build == 'true' && (needs.build-windows.result == 'success' || needs.build-macos.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -171,11 +204,13 @@ jobs:
               case "$name" in
                 *Setup*.exe) mv "$f" "assets/PortkeyDrop-nightly-${TIMESTAMP}-windows-setup.exe" ;;
                 *Portable*.zip) mv "$f" "assets/PortkeyDrop-nightly-${TIMESTAMP}-windows-portable.zip" ;;
+                *macOS*.zip) mv "$f" "assets/PortkeyDrop-nightly-${TIMESTAMP}-macOS.zip" ;;
               esac
             else
               case "$name" in
                 *Setup*.exe) mv "$f" "assets/PortkeyDrop-${VERSION}-windows-setup.exe" ;;
                 *Portable*.zip) mv "$f" "assets/PortkeyDrop-${VERSION}-windows-portable.zip" ;;
+                *macOS*.zip) mv "$f" "assets/PortkeyDrop-${VERSION}-macOS.zip" ;;
               esac
             fi
           done

--- a/installer/portkeydrop.spec
+++ b/installer/portkeydrop.spec
@@ -2,7 +2,7 @@
 PyInstaller spec file for PortkeyDrop.
 
 This spec file configures PyInstaller to build PortkeyDrop as a standalone
-application for Windows.
+application.
 
 Usage:
     pyinstaller installer/portkeydrop.spec
@@ -218,3 +218,18 @@ coll = COLLECT(
     upx_exclude=[],
     name=f"{APP_NAME}_dir",
 )
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        coll,
+        name=f"{APP_NAME}.app",
+        icon=ICON_PATH,
+        bundle_identifier=APP_BUNDLE_ID,
+        info_plist={
+            "CFBundleName": APP_NAME,
+            "CFBundleDisplayName": APP_NAME,
+            "CFBundleShortVersionString": APP_VERSION,
+            "CFBundleVersion": APP_VERSION,
+            "NSHighResolutionCapable": True,
+        },
+    )


### PR DESCRIPTION
## Summary
- Add a macOS build job to the release workflow, following AccessiWeather's current Windows + macOS artifact flow.
- Build macOS ZIP artifacts only by running the packaging script with `--skip-installer`.
- Add a PyInstaller macOS app bundle target so the packaging script can zip `PortkeyDrop.app`.
- Update release asset collection and renaming to include `PortkeyDrop-*-macOS.zip` assets.

## Verification
- python -c yaml.safe_load(.github/workflows/build.yml)
- python -m py_compile installer/portkeydrop.spec
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m pytest -q -n 0 --tb=short

## Notes
- macOS CI intentionally does not create or upload a DMG.
