### PR TITLE
feat(protocols): add experimental WebDAV support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- Experimental WebDAV connections for basic browse, upload, download, delete, folder creation, and rename workflows.
+
 ## [0.3.0] - 2026-03-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portkey Drop
 
-A keyboard-driven file transfer client supporting SFTP, FTP, and FTPS. Dual-pane interface with full keyboard navigation and screen reader compatibility (NVDA, JAWS).
+A keyboard-driven file transfer client supporting SFTP, FTP, FTPS, and experimental WebDAV. Dual-pane interface with full keyboard navigation and screen reader compatibility (NVDA, JAWS).
 
 ## Layout
 
@@ -37,11 +37,11 @@ Implemented:
 - **SFTP** (default) — SSH-based, most secure
 - **FTP** — Legacy support
 - **FTPS** — FTP over SSL/TLS
+- **WebDAV** — Experimental HTTP-based support for compatible servers and cloud services
 
 Planned:
 
 - **SCP** — Fast SSH transfers (planned)
-- **WebDAV** — HTTP-based, cloud service compatible (planned)
 
 ## Security
 

--- a/installer/portkeydrop.spec
+++ b/installer/portkeydrop.spec
@@ -92,6 +92,9 @@ binaries += asyncssh_binaries
 puttykeys_datas, puttykeys_binaries, puttykeys_hiddenimports = collect_all("puttykeys")
 datas += puttykeys_datas
 binaries += puttykeys_binaries
+webdav_datas, webdav_binaries, webdav_hiddenimports = collect_optional_all("webdav3")
+datas += webdav_datas
+binaries += webdav_binaries
 
 # Pull prism/prismatoid runtime package data/binaries for accessibility backend support
 prism_datas, prism_binaries, prism_hiddenimports = collect_optional_all("prism")
@@ -120,6 +123,8 @@ hiddenimports = [
     *asyncssh_hiddenimports,
     *collect_submodules("puttykeys"),
     *puttykeys_hiddenimports,
+    *collect_optional_submodules("webdav3"),
+    *webdav_hiddenimports,
     *collect_optional_submodules("prism"),
     *collect_optional_submodules("prismatoid"),
     *prism_hiddenimports,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "keyring>=25.0",
     "wxPython>=4.2",
     "prismatoid",
+    "webdavclient3>=3.14",
 ]
 
 [project.optional-dependencies]

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -42,7 +42,14 @@ from portkeydrop.migration import (
     migrate_files,
 )
 from portkeydrop.portable import get_config_dir, is_portable_mode
-from portkeydrop.protocols import ConnectionInfo, HostKeyPolicy, Protocol, RemoteFile, create_client
+from portkeydrop.protocols import (
+    SUPPORTED_PROTOCOL_VALUES,
+    ConnectionInfo,
+    HostKeyPolicy,
+    Protocol,
+    RemoteFile,
+    create_client,
+)
 from portkeydrop.settings import (
     load_settings,
     resolve_startup_local_folder,
@@ -248,7 +255,7 @@ class MainFrame(wx.Frame):
                 lbl.SetLabelFor(ctrl)
 
         protocol_lbl = wx.StaticText(toolbar_panel, label="&Protocol:")
-        self.tb_protocol = wx.Choice(toolbar_panel, choices=["sftp", "ftp", "ftps"])
+        self.tb_protocol = wx.Choice(toolbar_panel, choices=list(SUPPORTED_PROTOCOL_VALUES))
         self.tb_protocol.SetSelection(0)
         _bind_label(protocol_lbl, self.tb_protocol)
         sizer.Add(protocol_lbl, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
@@ -506,17 +513,18 @@ class MainFrame(wx.Frame):
 
     def _on_toolbar_protocol_change(self, event: wx.CommandEvent) -> None:
         proto = self.tb_protocol.GetStringSelection()
-        defaults = {"sftp": "22", "ftp": "21", "ftps": "990"}
+        defaults = {"sftp": "22", "ftp": "21", "ftps": "990", "webdav": "443"}
         self.tb_port.SetValue(defaults.get(proto, "22"))
 
     # --- Connection ---
 
     def _on_connect_toolbar(self, event: wx.CommandEvent) -> None:
-        proto_map = {"sftp": Protocol.SFTP, "ftp": Protocol.FTP, "ftps": Protocol.FTPS}
         proto_str = self.tb_protocol.GetStringSelection()
         port_str = self.tb_port.GetValue().strip()
         info = ConnectionInfo(
-            protocol=proto_map.get(proto_str, Protocol.SFTP),
+            protocol=Protocol(proto_str)
+            if proto_str in SUPPORTED_PROTOCOL_VALUES
+            else Protocol.SFTP,
             host=self.tb_host.GetValue().strip(),
             port=int(port_str) if port_str else 0,
             username=self.tb_username.GetValue().strip(),
@@ -640,7 +648,7 @@ class MainFrame(wx.Frame):
     def _effective_site_port(self, protocol: str, port: int) -> int:
         if port > 0:
             return port
-        defaults = {"sftp": 22, "ftp": 21, "ftps": 990}
+        defaults = {"sftp": 22, "ftp": 21, "ftps": 990, "webdav": 443}
         return defaults.get(protocol, 22)
 
     def _host_key_policy(self) -> HostKeyPolicy:

--- a/src/portkeydrop/dialogs/quick_connect.py
+++ b/src/portkeydrop/dialogs/quick_connect.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import wx
 
-from portkeydrop.protocols import ConnectionInfo, Protocol
+from portkeydrop.protocols import SUPPORTED_PROTOCOL_VALUES, ConnectionInfo, Protocol
 
 
 class QuickConnectDialog(wx.Dialog):
@@ -27,7 +27,7 @@ class QuickConnectDialog(wx.Dialog):
 
         # Protocol
         lbl = wx.StaticText(self, label="&Protocol:")
-        self.protocol_choice = wx.Choice(self, choices=["sftp", "ftp", "ftps"])
+        self.protocol_choice = wx.Choice(self, choices=list(SUPPORTED_PROTOCOL_VALUES))
         self.protocol_choice.SetSelection(0)
         _link(lbl, self.protocol_choice)  # pragma: no cover
         grid.Add(lbl, 0, wx.ALIGN_CENTER_VERTICAL)
@@ -83,16 +83,17 @@ class QuickConnectDialog(wx.Dialog):
 
     def _on_protocol_change(self, event: wx.CommandEvent) -> None:
         proto = self.protocol_choice.GetStringSelection()
-        defaults = {"sftp": "22", "ftp": "21", "ftps": "990"}
+        defaults = {"sftp": "22", "ftp": "21", "ftps": "990", "webdav": "443"}
         self.port_text.SetValue(defaults.get(proto, "22"))
 
     def get_connection_info(self) -> ConnectionInfo:
         """Return ConnectionInfo from dialog fields."""
-        proto_map = {"sftp": Protocol.SFTP, "ftp": Protocol.FTP, "ftps": Protocol.FTPS}
         proto_str = self.protocol_choice.GetStringSelection()
         port_str = self.port_text.GetValue().strip()
         return ConnectionInfo(
-            protocol=proto_map.get(proto_str, Protocol.SFTP),
+            protocol=Protocol(proto_str)
+            if proto_str in SUPPORTED_PROTOCOL_VALUES
+            else Protocol.SFTP,
             host=self.host_text.GetValue().strip(),
             port=int(port_str) if port_str else 0,
             username=self.username_text.GetValue().strip(),

--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import wx
 
+from portkeydrop.protocols import SUPPORTED_PROTOCOL_VALUES
 from portkeydrop.settings import Settings
 
 
@@ -298,7 +299,7 @@ class SettingsDialog(wx.Dialog):
             panel,
             sizer,
             label="&Default protocol:",
-            make_control=lambda p: wx.Choice(p, choices=["sftp", "ftp", "ftps"]),
+            make_control=lambda p: wx.Choice(p, choices=list(SUPPORTED_PROTOCOL_VALUES)),
             control_name="Default protocol",
         )
 
@@ -447,7 +448,7 @@ class SettingsDialog(wx.Dialog):
         idx = ["relative", "absolute"].index(s.display.date_format)
         self.date_format_choice.SetSelection(idx)
         # Connection
-        idx = ["sftp", "ftp", "ftps"].index(s.connection.protocol)
+        idx = list(SUPPORTED_PROTOCOL_VALUES).index(s.connection.protocol)
         self.default_proto_choice.SetSelection(idx)
         self.timeout_spin.SetValue(s.connection.timeout)
         self.keepalive_spin.SetValue(s.connection.keepalive)

--- a/src/portkeydrop/dialogs/site_manager.py
+++ b/src/portkeydrop/dialogs/site_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import wx
 
+from portkeydrop.protocols import SUPPORTED_PROTOCOL_VALUES
 from portkeydrop.sites import Site, SiteManager
 
 
@@ -60,7 +61,12 @@ class SiteManagerDialog(wx.Dialog):
 
         fields = [
             ("Na&me:", "name_text", wx.TextCtrl, {}),
-            ("Pro&tocol:", "protocol_choice", wx.Choice, {"choices": ["sftp", "ftp", "ftps"]}),
+            (
+                "Pro&tocol:",
+                "protocol_choice",
+                wx.Choice,
+                {"choices": list(SUPPORTED_PROTOCOL_VALUES)},
+            ),
             ("&Host:", "host_text", wx.TextCtrl, {}),
             ("Po&rt:", "port_text", wx.TextCtrl, {}),
             ("&Username:", "username_text", wx.TextCtrl, {}),
@@ -143,8 +149,8 @@ class SiteManagerDialog(wx.Dialog):
     def _populate_form(self, site: Site) -> None:
         self.name_text.SetValue(site.name)
         proto_idx = (
-            ["sftp", "ftp", "ftps"].index(site.protocol)
-            if site.protocol in ["sftp", "ftp", "ftps"]
+            list(SUPPORTED_PROTOCOL_VALUES).index(site.protocol)
+            if site.protocol in SUPPORTED_PROTOCOL_VALUES
             else 0
         )
         self.protocol_choice.SetSelection(proto_idx)

--- a/src/portkeydrop/protocols.py
+++ b/src/portkeydrop/protocols.py
@@ -12,13 +12,16 @@ import logging
 import os
 import ssl
 import stat
+import tempfile
 import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
+from email.utils import parsedate_to_datetime
 from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, BinaryIO, Callable
+from urllib.parse import urlsplit, urlunsplit
 
 if TYPE_CHECKING:
     import asyncssh
@@ -38,6 +41,9 @@ class Protocol(Enum):
     SFTP = "sftp"
     SCP = "scp"
     WEBDAV = "webdav"
+
+
+SUPPORTED_PROTOCOL_VALUES = ("sftp", "ftp", "ftps", "webdav")
 
 
 class HostKeyPolicy(Enum):
@@ -385,6 +391,198 @@ class FTPSClient(FTPClient):
         except Exception as e:
             self._connected = False
             raise ConnectionError(f"FTPS connection failed: {e}") from e
+
+
+class WebDAVClient(TransferClient):
+    """Experimental WebDAV protocol client using webdavclient3."""
+
+    def __init__(self, info: ConnectionInfo) -> None:
+        super().__init__(info)
+        self._client = None
+
+    def connect(self) -> None:
+        try:
+            from webdav3.client import Client
+
+            self._client = Client(
+                {
+                    "webdav_hostname": self._build_hostname(),
+                    "webdav_login": self._info.username,
+                    "webdav_password": self._info.password,
+                    "webdav_timeout": self._info.timeout,
+                }
+            )
+            self._cwd = "/"
+            self._connected = True
+        except ImportError as e:
+            self._connected = False
+            raise ConnectionError(
+                "WebDAV support is not installed. Install PortkeyDrop with WebDAV support."
+            ) from e
+        except Exception as e:
+            self._connected = False
+            raise ConnectionError(f"WebDAV connection failed: {e}") from e
+
+    def disconnect(self) -> None:
+        self._client = None
+        self._connected = False
+
+    def _ensure_connected(self):
+        if not self._client or not self._connected:
+            raise ConnectionError("Not connected")
+        return self._client
+
+    def _build_hostname(self) -> str:
+        raw_host = self._info.host.strip()
+        if "://" not in raw_host:
+            scheme = "http" if self._info.effective_port == 80 else "https"
+            raw_host = f"{scheme}://{raw_host}"
+        parts = urlsplit(raw_host)
+        hostname = parts.hostname or self._info.host.strip()
+        port = self._info.effective_port
+        default_port = 80 if parts.scheme == "http" else 443
+        netloc = hostname
+        if port and port != default_port:
+            netloc = f"{hostname}:{port}"
+        if parts.username or parts.password:
+            userinfo = parts.username or ""
+            if parts.password:
+                userinfo += f":{parts.password}"
+            netloc = f"{userinfo}@{netloc}"
+        return urlunsplit((parts.scheme or "https", netloc, parts.path, parts.query, ""))
+
+    def _resolve_path(self, path: str = ".") -> str:
+        if not path or path == ".":
+            return self._cwd
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute():
+            resolved = str(candidate)
+        else:
+            resolved = str(PurePosixPath(self._cwd) / candidate)
+        if path.endswith("/") and not resolved.endswith("/"):
+            resolved += "/"
+        return resolved if resolved.startswith("/") else f"/{resolved}"
+
+    @staticmethod
+    def _parse_modified(value: object) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.replace(tzinfo=None)
+        try:
+            return parsedate_to_datetime(str(value)).replace(tzinfo=None)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _is_dir_info(info: dict) -> bool:
+        for key in ("isdir", "is_dir", "directory"):
+            value = info.get(key)
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str) and value.lower() in {"true", "1", "yes", "dir", "directory"}:
+                return True
+        path = str(info.get("path") or info.get("href") or info.get("name") or "")
+        content_type = str(info.get("content_type") or info.get("content-type") or "").lower()
+        return path.endswith("/") or content_type == "httpd/unix-directory"
+
+    def _remote_file_from_info(self, info: dict, fallback_path: str = "") -> RemoteFile:
+        path = str(info.get("path") or info.get("href") or fallback_path)
+        name = str(
+            info.get("name") or PurePosixPath(path.rstrip("/")).name or path.strip("/") or "/"
+        )
+        is_dir = self._is_dir_info(info)
+        try:
+            size = 0 if is_dir else int(info.get("size") or info.get("content_length") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        modified = self._parse_modified(
+            info.get("modified") or info.get("modified_at") or info.get("lastmodified")
+        )
+        if path and not path.startswith("/"):
+            path = f"/{path}"
+        return RemoteFile(name=name, path=path, size=size, is_dir=is_dir, modified=modified)
+
+    def list_dir(self, path: str = ".") -> list[RemoteFile]:
+        client = self._ensure_connected()
+        target = self._resolve_path(path)
+        items = client.list(target, get_info=True)
+        return [self._remote_file_from_info(item) for item in items if isinstance(item, dict)]
+
+    def chdir(self, path: str) -> str:
+        remote = self.stat(self._resolve_path(path))
+        if not remote.is_dir:
+            raise NotADirectoryError(path)
+        self._cwd = remote.path if remote.path.endswith("/") else f"{remote.path}/"
+        return self._cwd
+
+    def download(
+        self,
+        remote_path: str,
+        local_file: BinaryIO,
+        callback: ProgressCallback | None = None,
+        offset: int = 0,
+    ) -> None:
+        if offset:
+            raise ValueError("WebDAV downloads do not support resume yet")
+        client = self._ensure_connected()
+        target = self._resolve_path(remote_path)
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            client.download(target, tmp_path)
+            with open(tmp_path, "rb") as fh:
+                data = fh.read()
+            local_file.write(data)
+            if callback:
+                callback(len(data), len(data))
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    def upload(
+        self, local_file: BinaryIO, remote_path: str, callback: ProgressCallback | None = None
+    ) -> None:
+        client = self._ensure_connected()
+        target = self._resolve_path(remote_path)
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+            local_file.seek(0)
+            data = local_file.read()
+            tmp.write(data)
+        try:
+            client.upload(remote_path=target, local_path=tmp_path)
+            if callback:
+                callback(len(data), len(data))
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    def delete(self, path: str) -> None:
+        self._ensure_connected().clean(self._resolve_path(path))
+
+    def rmdir(self, path: str) -> None:
+        self._ensure_connected().clean(self._resolve_path(path))
+
+    def mkdir(self, path: str) -> None:
+        self._ensure_connected().mkdir(self._resolve_path(path))
+
+    def rename(self, old_path: str, new_path: str) -> None:
+        self._ensure_connected().move(
+            remote_path_from=self._resolve_path(old_path),
+            remote_path_to=self._resolve_path(new_path),
+        )
+
+    def stat(self, path: str) -> RemoteFile:
+        target = self._resolve_path(path)
+        info = self._ensure_connected().info(target)
+        if not isinstance(info, dict):
+            raise FileNotFoundError(path)
+        return self._remote_file_from_info(info, fallback_path=target)
 
 
 class SFTPClient(TransferClient):
@@ -1563,6 +1761,7 @@ def create_client(info: ConnectionInfo) -> TransferClient:
         Protocol.FTP: FTPClient,
         Protocol.FTPS: FTPSClient,
         Protocol.SFTP: SFTPClient,
+        Protocol.WEBDAV: WebDAVClient,
     }
     client_class = clients.get(info.protocol)
     if client_class is None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -703,6 +703,24 @@ def test_apply_connection_defaults_sets_timeout_passive_and_host_key_policy(app_
     assert info.host_key_policy == app.HostKeyPolicy.STRICT
 
 
+def test_toolbar_protocol_change_uses_webdav_default_port(app_module):
+    _app, _ = app_module
+    frame = _hydrate_frame(app_module)
+    frame.tb_protocol = MagicMock(GetStringSelection=MagicMock(return_value="webdav"))
+    frame.tb_port = MagicMock()
+
+    frame._on_toolbar_protocol_change(None)
+
+    frame.tb_port.SetValue.assert_called_once_with("443")
+
+
+def test_effective_site_port_uses_webdav_default(app_module):
+    _app, _ = app_module
+    frame = _hydrate_frame(app_module)
+
+    assert frame._effective_site_port("webdav", 0) == 443
+
+
 def test_quick_connect_applies_connection_defaults(app_module):
     app, fake_wx = app_module
     frame = _hydrate_frame(app_module)

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import builtins
 import base64
 import hashlib
 import hmac
@@ -10,6 +11,7 @@ import sys
 import stat as stat_mod
 import types
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +24,7 @@ from portkeydrop.protocols import (
     Protocol,
     RemoteFile,
     SFTPClient,
+    WebDAVClient,
     create_client,
 )
 
@@ -212,10 +215,305 @@ class TestCreateClient:
         assert isinstance(ftp_client, FTPClient)
         assert isinstance(ftps_client, FTPSClient)
 
-    def test_create_unsupported_raises(self):
+    def test_create_webdav_client(self):
         info = ConnectionInfo(protocol=Protocol.WEBDAV, host="example.com")
-        with pytest.raises(ValueError, match="not yet supported"):
-            create_client(info)
+        client = create_client(info)
+        assert isinstance(client, WebDAVClient)
+
+
+class TestWebDAVClient:
+    def _install_fake_webdav(self, monkeypatch, client):
+        fake_client_mod = types.ModuleType("webdav3.client")
+        fake_client_mod.Client = MagicMock(return_value=client)
+        fake_pkg = types.ModuleType("webdav3")
+        fake_pkg.client = fake_client_mod
+        monkeypatch.setitem(sys.modules, "webdav3", fake_pkg)
+        monkeypatch.setitem(sys.modules, "webdav3.client", fake_client_mod)
+        return fake_client_mod.Client
+
+    def test_connect_builds_webdavclient_options(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        client_class = self._install_fake_webdav(monkeypatch, webdav)
+        info = ConnectionInfo(
+            protocol=Protocol.WEBDAV,
+            host="dav.example.com",
+            username="alice",
+            password="secret",
+            timeout=12,
+        )
+
+        client = WebDAVClient(info)
+        client.connect()
+
+        client_class.assert_called_once_with(
+            {
+                "webdav_hostname": "https://dav.example.com",
+                "webdav_login": "alice",
+                "webdav_password": "secret",
+                "webdav_timeout": 12,
+            }
+        )
+        assert client.connected
+        assert client.cwd == "/"
+
+    def test_connect_preserves_explicit_webdav_url_and_port(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        client_class = self._install_fake_webdav(monkeypatch, webdav)
+        info = ConnectionInfo(
+            protocol=Protocol.WEBDAV,
+            host="http://dav.example.com/root",
+            port=8080,
+            username="alice",
+            password="secret",
+        )
+
+        WebDAVClient(info).connect()
+
+        assert (
+            client_class.call_args.args[0]["webdav_hostname"] == "http://dav.example.com:8080/root"
+        )
+
+    def test_list_dir_maps_webdav_items(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = [
+            {
+                "path": "/docs/",
+                "name": "docs",
+                "isdir": True,
+                "size": "0",
+                "modified": "Tue, 05 May 2026 10:15:00 GMT",
+            },
+            {
+                "path": "/readme.txt",
+                "name": "readme.txt",
+                "isdir": False,
+                "size": "12",
+            },
+        ]
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        files = client.list_dir("/")
+
+        webdav.list.assert_called_once_with("/", get_info=True)
+        assert files[0] == RemoteFile(
+            name="docs",
+            path="/docs/",
+            size=0,
+            is_dir=True,
+            modified=datetime(2026, 5, 5, 10, 15),
+        )
+        assert files[1].name == "readme.txt"
+        assert files[1].size == 12
+        assert files[1].is_dir is False
+
+    def test_stat_maps_webdav_info(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        webdav.info.return_value = {
+            "path": "/docs/",
+            "name": "docs",
+            "isdir": True,
+            "size": "0",
+            "modified": "Tue, 05 May 2026 10:15:00 GMT",
+        }
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        remote = client.stat("/docs/")
+
+        webdav.info.assert_called_once_with("/docs/")
+        assert remote.name == "docs"
+        assert remote.path == "/docs/"
+        assert remote.is_dir is True
+
+    def test_chdir_requires_existing_directory(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        webdav.info.return_value = {"path": "/docs/", "name": "docs", "isdir": True}
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        assert client.chdir("docs") == "/docs/"
+        assert client.cwd == "/docs/"
+
+    def test_file_operations_delegate_to_webdavclient(self, monkeypatch, tmp_path):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        webdav.info.return_value = {"path": "/file.txt", "name": "file.txt", "size": "5"}
+
+        def fake_download(remote_path, local_path):
+            Path(local_path).write_bytes(b"hello")
+
+        uploaded: dict[str, bytes] = {}
+
+        def fake_upload(*, remote_path, local_path):
+            uploaded["remote_path"] = remote_path
+            uploaded["data"] = Path(local_path).read_bytes()
+
+        webdav.download.side_effect = fake_download
+        webdav.upload.side_effect = fake_upload
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        out = io.BytesIO()
+        progress: list[tuple[int, int]] = []
+        client.download(
+            "/file.txt", out, callback=lambda done, total: progress.append((done, total))
+        )
+        assert out.getvalue() == b"hello"
+        assert progress == [(5, 5)]
+
+        src = tmp_path / "upload.txt"
+        src.write_bytes(b"data")
+        progress.clear()
+        with src.open("rb") as fh:
+            client.upload(
+                fh, "/upload.txt", callback=lambda done, total: progress.append((done, total))
+            )
+
+        webdav.upload.assert_called_once()
+        assert uploaded == {"remote_path": "/upload.txt", "data": b"data"}
+        assert progress == [(4, 4)]
+
+        client.delete("/old.txt")
+        client.rmdir("/old-dir/")
+        client.mkdir("/new/")
+        client.rename("/old.txt", "/new.txt")
+
+        webdav.clean.assert_any_call("/old.txt")
+        webdav.clean.assert_any_call("/old-dir/")
+        webdav.mkdir.assert_called_once_with("/new/")
+        webdav.move.assert_called_once_with(remote_path_from="/old.txt", remote_path_to="/new.txt")
+
+    def test_connect_reports_missing_webdav_dependency(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "webdav3.client":
+                raise ImportError("missing webdav")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+
+        with pytest.raises(ConnectionError, match="WebDAV support is not installed"):
+            client.connect()
+
+        assert not client.connected
+
+    def test_connect_wraps_webdavclient_errors(self, monkeypatch):
+        fake_client_mod = types.ModuleType("webdav3.client")
+        fake_client_mod.Client = MagicMock(side_effect=RuntimeError("boom"))
+        fake_pkg = types.ModuleType("webdav3")
+        fake_pkg.client = fake_client_mod
+        monkeypatch.setitem(sys.modules, "webdav3", fake_pkg)
+        monkeypatch.setitem(sys.modules, "webdav3.client", fake_client_mod)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+
+        with pytest.raises(ConnectionError, match="WebDAV connection failed"):
+            client.connect()
+
+        assert not client.connected
+
+    def test_disconnect_and_disconnected_operations(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        client.disconnect()
+
+        assert not client.connected
+        with pytest.raises(ConnectionError, match="Not connected"):
+            client.list_dir()
+
+    def test_build_hostname_preserves_userinfo_and_relative_paths(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        client_class = self._install_fake_webdav(monkeypatch, webdav)
+        info = ConnectionInfo(
+            protocol=Protocol.WEBDAV,
+            host="https://bob:secret@dav.example.com/root",
+        )
+        client = WebDAVClient(info)
+        client.connect()
+        client._cwd = "/root/"
+
+        assert client_class.call_args.args[0]["webdav_hostname"] == (
+            "https://bob:secret@dav.example.com/root"
+        )
+        assert client._resolve_path(".") == "/root/"
+        assert client._resolve_path("folder/") == "/root/folder/"
+
+    def test_metadata_edge_cases(self):
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+
+        assert client._parse_modified(datetime(2026, 5, 5, 10, 15)) == datetime(2026, 5, 5, 10, 15)
+        assert client._parse_modified("not a date") is None
+        assert client._is_dir_info({"isdir": "yes"}) is True
+        assert client._is_dir_info({"path": "/collection/"}) is True
+        assert client._is_dir_info({"content_type": "httpd/unix-directory"}) is True
+        remote = client._remote_file_from_info(
+            {"href": "file.txt", "size": "not-a-number"},
+            fallback_path="fallback.txt",
+        )
+        assert remote.path == "/file.txt"
+        assert remote.size == 0
+
+    def test_chdir_rejects_files_and_stat_requires_dict(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        webdav.info.side_effect = [
+            {"path": "/file.txt", "name": "file.txt", "isdir": False},
+            None,
+        ]
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        with pytest.raises(NotADirectoryError):
+            client.chdir("/file.txt")
+        with pytest.raises(FileNotFoundError):
+            client.stat("/missing")
+
+    def test_download_resume_and_temp_cleanup_edges(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+
+        with pytest.raises(ValueError, match="do not support resume"):
+            client.download("/file.txt", io.BytesIO(), offset=1)
+
+        def fake_download(remote_path, local_path):
+            Path(local_path).write_bytes(b"x")
+
+        webdav.download.side_effect = fake_download
+        monkeypatch.setattr("portkeydrop.protocols.os.unlink", MagicMock(side_effect=OSError))
+        out = io.BytesIO()
+        client.download("/file.txt", out)
+        assert out.getvalue() == b"x"
+
+    def test_upload_temp_cleanup_edge(self, monkeypatch):
+        webdav = MagicMock()
+        webdav.list.return_value = []
+        self._install_fake_webdav(monkeypatch, webdav)
+        client = WebDAVClient(ConnectionInfo(protocol=Protocol.WEBDAV, host="dav.example.com"))
+        client.connect()
+        monkeypatch.setattr("portkeydrop.protocols.os.unlink", MagicMock(side_effect=OSError))
+
+        client.upload(io.BytesIO(b"x"), "/file.txt")
+
+        webdav.upload.assert_called_once()
 
 
 class TestFTPClient:

--- a/tests/test_quick_connect_dialog.py
+++ b/tests/test_quick_connect_dialog.py
@@ -1,0 +1,116 @@
+"""Tests for the Quick Connect dialog protocol choices."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+class _Window:
+    def Bind(self, *_args, **_kwargs):
+        return None
+
+    def SetFocus(self):
+        return None
+
+
+class _Dialog(_Window):
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+    def SetSizer(self, *_args, **_kwargs):
+        return None
+
+    def Fit(self):
+        return None
+
+    def FindWindowById(self, _id):
+        return _Button()
+
+    def CreateStdDialogButtonSizer(self, *_args, **_kwargs):
+        return _Sizer()
+
+
+class _Sizer:
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+    def Add(self, *_args, **_kwargs):
+        return None
+
+    def AddGrowableCol(self, *_args, **_kwargs):
+        return None
+
+
+class _StaticText(_Window):
+    def __init__(self, *_args, **_kwargs):
+        self.label_for = None
+
+    def SetLabelFor(self, ctrl):
+        self.label_for = ctrl
+
+
+class _Choice(_Window):
+    def __init__(self, *_args, choices=None, **_kwargs):
+        self.choices = choices or []
+        self.selection = 0
+
+    def SetSelection(self, selection):
+        self.selection = selection
+
+    def GetStringSelection(self):
+        return self.choices[self.selection]
+
+
+class _TextCtrl(_Window):
+    def __init__(self, *_args, value="", **_kwargs):
+        self.value = value
+
+    def SetValue(self, value):
+        self.value = value
+
+    def GetValue(self):
+        return self.value
+
+
+class _Button(_Window):
+    def SetDefault(self):
+        return None
+
+
+def _load_quick_connect(monkeypatch):
+    wx = types.ModuleType("wx")
+    wx.Dialog = _Dialog
+    wx.Window = _Window
+    wx.BoxSizer = _Sizer
+    wx.FlexGridSizer = _Sizer
+    wx.StaticText = _StaticText
+    wx.Choice = _Choice
+    wx.TextCtrl = _TextCtrl
+    wx.DEFAULT_DIALOG_STYLE = 1
+    wx.VERTICAL = 2
+    wx.EXPAND = 4
+    wx.ALL = 8
+    wx.ALIGN_CENTER_VERTICAL = 16
+    wx.TE_PASSWORD = 32
+    wx.OK = 64
+    wx.CANCEL = 128
+    wx.ID_OK = 1
+    wx.EVT_CHOICE = object()
+    monkeypatch.setitem(sys.modules, "wx", wx)
+    sys.modules.pop("portkeydrop.dialogs.quick_connect", None)
+    return importlib.import_module("portkeydrop.dialogs.quick_connect")
+
+
+def test_quick_connect_exposes_webdav_and_default_port(monkeypatch):
+    module = _load_quick_connect(monkeypatch)
+    dialog = module.QuickConnectDialog()
+
+    assert dialog.protocol_choice.choices == ["sftp", "ftp", "ftps", "webdav"]
+
+    dialog.protocol_choice.SetSelection(3)
+    dialog._on_protocol_change(None)
+
+    assert dialog.port_text.GetValue() == "443"
+    assert dialog.get_connection_info().protocol is module.Protocol.WEBDAV


### PR DESCRIPTION
## Summary
- add an experimental WebDAV transfer client for basic browse/upload/download/delete/mkdir/rename/stat workflows
- expose `webdav` in toolbar, Quick Connect, Site Manager, and default protocol settings
- include `webdavclient3` in runtime packaging and document the feature as experimental

## Verification
- `.\\.venv\\Scripts\\python.exe -m ruff check .`
- `.\\.venv\\Scripts\\python.exe -m pytest --cov=src/portkeydrop --cov-report=xml`
- `.\\.venv\\Scripts\\python.exe -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/dev --fail-under=98`

## Notes
- WebDAV is intentionally marked experimental pending real-provider smoke testing.
- Implementation was checked against `webdavclient3` documentation and installed API signatures.
