### PR TITLE
feat(ftp): add explicit AUTH SSL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- FTP connections can now enable explicit SSL with the AUTH SSL command.
 - Experimental WebDAV connections for basic browse, upload, download, delete, folder creation, and rename workflows.
 
 ## [0.3.0] - 2026-03-23

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Implemented:
 
 - **SFTP** (default) — SSH-based, most secure
 - **FTP** — Legacy support
+- **FTP with SSL (AUTH SSL)** — Explicit SSL upgrade for FTP servers which require it
 - **FTPS** — FTP over SSL/TLS
 - **WebDAV** — Experimental HTTP-based support for compatible servers and cloud services
 

--- a/src/portkeydrop/app.py
+++ b/src/portkeydrop/app.py
@@ -285,6 +285,11 @@ class MainFrame(wx.Frame):
         sizer.Add(password_lbl, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 8)
         sizer.Add(self.tb_password, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
 
+        self.tb_ftp_ssl = wx.CheckBox(toolbar_panel, label="Use SSL (AUTH SSL)")
+        self.tb_ftp_ssl.SetName("Use SSL with FTP")
+        self.tb_ftp_ssl.Enable(False)
+        sizer.Add(self.tb_ftp_ssl, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 8)
+
         self.tb_connect_btn = wx.Button(toolbar_panel, label="&Connect")
         sizer.Add(self.tb_connect_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 8)
 
@@ -513,8 +518,16 @@ class MainFrame(wx.Frame):
 
     def _on_toolbar_protocol_change(self, event: wx.CommandEvent) -> None:
         proto = self.tb_protocol.GetStringSelection()
-        defaults = {"sftp": "22", "ftp": "21", "ftps": "990", "webdav": "443"}
+        defaults = {
+            "sftp": "22",
+            "ftp": "21",
+            "ftps": "990",
+            "webdav": "443",
+        }
         self.tb_port.SetValue(defaults.get(proto, "22"))
+        self.tb_ftp_ssl.Enable(proto == "ftp")
+        if proto != "ftp":
+            self.tb_ftp_ssl.SetValue(False)
 
     # --- Connection ---
 
@@ -529,6 +542,7 @@ class MainFrame(wx.Frame):
             port=int(port_str) if port_str else 0,
             username=self.tb_username.GetValue().strip(),
             password=self.tb_password.GetValue(),
+            ftp_explicit_ssl=bool(self.tb_ftp_ssl.GetValue()) if proto_str == "ftp" else False,
         )
         self._apply_connection_defaults(info)
         self._do_connect(info)
@@ -581,6 +595,7 @@ class MainFrame(wx.Frame):
                 port=int(port_str) if port_str else 0,
                 username=username,
                 password=password,
+                ftp_explicit_ssl=bool(self.tb_ftp_ssl.GetValue()) if proto_str == "ftp" else False,
                 initial_dir=self._client.cwd,
             )
             self._site_manager.add(site)
@@ -626,6 +641,7 @@ class MainFrame(wx.Frame):
                 username=imported.username,
                 password=imported.password,
                 key_path=imported.key_path,
+                ftp_explicit_ssl=getattr(imported, "ftp_explicit_ssl", False),
                 initial_dir=imported.initial_dir or "/",
                 notes=imported.notes,
             )
@@ -666,6 +682,10 @@ class MainFrame(wx.Frame):
         defaults = getattr(self._settings, "connection", None)
         info.timeout = max(1, int(getattr(defaults, "timeout", info.timeout)))
         info.passive_mode = bool(getattr(defaults, "passive_mode", info.passive_mode))
+        if info.protocol is Protocol.FTP:
+            info.ftp_explicit_ssl = bool(
+                info.ftp_explicit_ssl or getattr(defaults, "ftp_explicit_ssl", False)
+            )
         info.host_key_policy = self._host_key_policy()
 
     def _do_connect(self, info: ConnectionInfo) -> None:

--- a/src/portkeydrop/dialogs/quick_connect.py
+++ b/src/portkeydrop/dialogs/quick_connect.py
@@ -61,6 +61,13 @@ class QuickConnectDialog(wx.Dialog):
         grid.Add(lbl, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(self.password_text, 1, wx.EXPAND)
 
+        # FTP SSL
+        self.ftp_ssl_check = wx.CheckBox(self, label="Use SSL (AUTH SSL)")
+        self.ftp_ssl_check.SetName("Use SSL with FTP")
+        self.ftp_ssl_check.Enable(False)
+        grid.Add(wx.StaticText(self, label=""))
+        grid.Add(self.ftp_ssl_check, 1, wx.EXPAND)
+
         sizer.Add(grid, 1, wx.ALL | wx.EXPAND, 10)
 
         # Buttons
@@ -83,8 +90,16 @@ class QuickConnectDialog(wx.Dialog):
 
     def _on_protocol_change(self, event: wx.CommandEvent) -> None:
         proto = self.protocol_choice.GetStringSelection()
-        defaults = {"sftp": "22", "ftp": "21", "ftps": "990", "webdav": "443"}
+        defaults = {
+            "sftp": "22",
+            "ftp": "21",
+            "ftps": "990",
+            "webdav": "443",
+        }
         self.port_text.SetValue(defaults.get(proto, "22"))
+        self.ftp_ssl_check.Enable(proto == "ftp")
+        if proto != "ftp":
+            self.ftp_ssl_check.SetValue(False)
 
     def get_connection_info(self) -> ConnectionInfo:
         """Return ConnectionInfo from dialog fields."""
@@ -98,4 +113,5 @@ class QuickConnectDialog(wx.Dialog):
             port=int(port_str) if port_str else 0,
             username=self.username_text.GetValue().strip(),
             password=self.password_text.GetValue(),
+            ftp_explicit_ssl=bool(self.ftp_ssl_check.GetValue()) if proto_str == "ftp" else False,
         )

--- a/src/portkeydrop/dialogs/settings.py
+++ b/src/portkeydrop/dialogs/settings.py
@@ -336,6 +336,12 @@ class SettingsDialog(wx.Dialog):
             name="Passive mode",
         )
 
+        self.ftp_ssl_check = self._add_checkbox_row(
+            sizer,
+            wx.CheckBox(panel, label="Use SSL (AUTH SSL) by default for FTP"),
+            name="Use SSL with FTP by default",
+        )
+
         self.verify_keys_choice = self._add_labeled_row(
             panel,
             sizer,
@@ -454,6 +460,7 @@ class SettingsDialog(wx.Dialog):
         self.keepalive_spin.SetValue(s.connection.keepalive)
         self.retries_spin.SetValue(s.connection.max_retries)
         self.passive_check.SetValue(s.connection.passive_mode)
+        self.ftp_ssl_check.SetValue(s.connection.ftp_explicit_ssl)
         idx = ["ask", "always", "never"].index(s.connection.verify_host_keys)
         self.verify_keys_choice.SetSelection(idx)
         self.remember_local_folder_check.SetValue(s.app.remember_last_local_folder_on_startup)
@@ -491,6 +498,7 @@ class SettingsDialog(wx.Dialog):
         s.connection.keepalive = self.keepalive_spin.GetValue()
         s.connection.max_retries = self.retries_spin.GetValue()
         s.connection.passive_mode = self.passive_check.GetValue()
+        s.connection.ftp_explicit_ssl = self.ftp_ssl_check.GetValue()
         s.connection.verify_host_keys = self.verify_keys_choice.GetStringSelection()
         s.app.remember_last_local_folder_on_startup = self.remember_local_folder_check.GetValue()
         s.app.auto_update_enabled = self.auto_update_check.GetValue()

--- a/src/portkeydrop/dialogs/site_manager.py
+++ b/src/portkeydrop/dialogs/site_manager.py
@@ -71,6 +71,7 @@ class SiteManagerDialog(wx.Dialog):
             ("Po&rt:", "port_text", wx.TextCtrl, {}),
             ("&Username:", "username_text", wx.TextCtrl, {}),
             ("Pass&word:", "password_text", wx.TextCtrl, {"style": wx.TE_PASSWORD}),
+            ("", "ftp_ssl_check", wx.CheckBox, {"label": "Use SSL (AUTH SSL)"}),
             ("&Key Path:", "key_path_text", wx.TextCtrl, {}),
             ("&Initial Dir:", "initial_dir_text", wx.TextCtrl, {}),
         ]
@@ -128,6 +129,7 @@ class SiteManagerDialog(wx.Dialog):
         self.add_btn.Bind(wx.EVT_BUTTON, self._on_add)
         self.remove_btn.Bind(wx.EVT_BUTTON, self._on_remove)
         self.connect_btn.Bind(wx.EVT_BUTTON, self._on_connect)
+        self.protocol_choice.Bind(wx.EVT_CHOICE, self._on_protocol_change)
         save_btn.Bind(wx.EVT_BUTTON, self._on_save)
         self.Bind(wx.EVT_CHAR_HOOK, self._on_char_hook)
 
@@ -158,6 +160,9 @@ class SiteManagerDialog(wx.Dialog):
         self.port_text.SetValue(str(site.port) if site.port else "")
         self.username_text.SetValue(site.username)
         self.password_text.SetValue(site.password)
+        if hasattr(self, "ftp_ssl_check"):
+            self.ftp_ssl_check.SetValue(bool(getattr(site, "ftp_explicit_ssl", False)))
+            self.ftp_ssl_check.Enable(site.protocol == "ftp")
         self.key_path_text.SetValue(site.key_path)
         self.initial_dir_text.SetValue(site.initial_dir)
 
@@ -177,6 +182,12 @@ class SiteManagerDialog(wx.Dialog):
             self.EndModal(wx.ID_CANCEL)
         else:
             event.Skip()
+
+    def _on_protocol_change(self, event: wx.CommandEvent) -> None:
+        is_ftp = self.protocol_choice.GetStringSelection() == "ftp"
+        self.ftp_ssl_check.Enable(is_ftp)
+        if not is_ftp:
+            self.ftp_ssl_check.SetValue(False)
 
     def _on_remove(self, event: wx.CommandEvent) -> None:
         if self._selected_site:
@@ -294,6 +305,11 @@ class SiteManagerDialog(wx.Dialog):
             site.port = 0
         site.username = self.username_text.GetValue().strip()
         site.password = self.password_text.GetValue()
+        site.ftp_explicit_ssl = (
+            bool(self.ftp_ssl_check.GetValue())
+            if site.protocol == "ftp" and hasattr(self, "ftp_ssl_check")
+            else False
+        )
         site.key_path = self.key_path_text.GetValue().strip()
         site.initial_dir = self.initial_dir_text.GetValue().strip() or "/"
         return True

--- a/src/portkeydrop/importers/filezilla.py
+++ b/src/portkeydrop/importers/filezilla.py
@@ -13,7 +13,7 @@ from .models import ImportedSite
 _PROTOCOL_MAP = {
     "0": "ftp",
     "1": "sftp",
-    "3": "ftps",
+    "3": "ftp",
     "4": "ftps",
 }
 
@@ -41,6 +41,7 @@ def _parse_root(root: ET.Element) -> list[ImportedSite]:
 
         raw_protocol = (server.findtext("Protocol") or "1").strip()
         protocol = _PROTOCOL_MAP.get(raw_protocol, "sftp")
+        ftp_explicit_ssl = raw_protocol == "3"
 
         raw_port = (server.findtext("Port") or "").strip()
         port = int(raw_port) if raw_port.isdigit() else 0
@@ -64,6 +65,7 @@ def _parse_root(root: ET.Element) -> list[ImportedSite]:
                 username=username,
                 password=password,
                 key_path=key_path,
+                ftp_explicit_ssl=ftp_explicit_ssl,
                 initial_dir=initial_dir,
                 notes=notes,
             )

--- a/src/portkeydrop/importers/models.py
+++ b/src/portkeydrop/importers/models.py
@@ -16,5 +16,6 @@ class ImportedSite:
     username: str = ""
     password: str = ""
     key_path: str = ""
+    ftp_explicit_ssl: bool = False
     initial_dir: str = "/"
     notes: str = ""

--- a/src/portkeydrop/importers/winscp.py
+++ b/src/portkeydrop/importers/winscp.py
@@ -123,6 +123,9 @@ def _parse_site(
     protocol = _detect_protocol(cfg)
     if protocol == "scp":
         protocol = "sftp"
+    ftp_explicit_ssl = protocol == "ftps" and port != 990
+    if ftp_explicit_ssl:
+        protocol = "ftp"
 
     username = str(cfg.get("UserName", "")).strip()
     initial_dir = _decode_value(str(cfg.get("RemoteDirectory", "")).strip()) or "/"
@@ -137,6 +140,7 @@ def _parse_site(
         port=port,
         username=username,
         password=password,
+        ftp_explicit_ssl=ftp_explicit_ssl,
         key_path=key_path,
         initial_dir=initial_dir,
     )

--- a/src/portkeydrop/protocols.py
+++ b/src/portkeydrop/protocols.py
@@ -98,12 +98,15 @@ class ConnectionInfo:
     key_path: str = ""
     timeout: int = 30
     passive_mode: bool = True  # FTP only
+    ftp_explicit_ssl: bool = False  # FTP AUTH SSL
     host_key_policy: HostKeyPolicy = HostKeyPolicy.AUTO_ADD
 
     @property
     def effective_port(self) -> int:
         if self.port > 0:
             return self.port
+        if self.protocol is Protocol.FTP and self.ftp_explicit_ssl:
+            return 21
         defaults = {
             Protocol.FTP: 21,
             Protocol.FTPS: 990,
@@ -391,6 +394,38 @@ class FTPSClient(FTPClient):
         except Exception as e:
             self._connected = False
             raise ConnectionError(f"FTPS connection failed: {e}") from e
+
+
+class AuthSSLFTP_TLS(ftplib.FTP_TLS):
+    """FTP_TLS variant for servers which require the legacy AUTH SSL command."""
+
+    def auth(self) -> None:
+        if self.sock is None:
+            raise ValueError("Not connected")
+        if isinstance(self.sock, ssl.SSLSocket):
+            return
+        self.voidcmd("AUTH SSL")
+        self.sock = self.context.wrap_socket(self.sock, server_hostname=self.host)
+        self.file = self.sock.makefile(mode="r", encoding=self.encoding)
+
+
+class FTPSAuthSSLClient(FTPSClient):
+    """Explicit FTP over SSL client using AUTH SSL on the control connection."""
+
+    def connect(self) -> None:
+        try:
+            ctx = ssl.create_default_context()
+            self._ftp = AuthSSLFTP_TLS(context=ctx)
+            self._ftp.connect(self._info.host, self._info.effective_port, self._info.timeout)
+            self._ftp.login(self._info.username, self._info.password)
+            self._ftp.prot_p()
+            if self._info.passive_mode:
+                self._ftp.set_pasv(True)
+            self._cwd = self._ftp.pwd()
+            self._connected = True
+        except Exception as e:
+            self._connected = False
+            raise ConnectionError(f"FTP explicit SSL connection failed: {e}") from e
 
 
 class WebDAVClient(TransferClient):
@@ -1763,6 +1798,8 @@ def create_client(info: ConnectionInfo) -> TransferClient:
         Protocol.SFTP: SFTPClient,
         Protocol.WEBDAV: WebDAVClient,
     }
+    if info.protocol is Protocol.FTP and info.ftp_explicit_ssl:
+        return FTPSAuthSSLClient(info)
     client_class = clients.get(info.protocol)
     if client_class is None:
         raise ValueError(f"Protocol {info.protocol.value} is not yet supported")

--- a/src/portkeydrop/settings.py
+++ b/src/portkeydrop/settings.py
@@ -41,6 +41,7 @@ class ConnectionDefaults:
     keepalive: int = 60
     max_retries: int = 3
     passive_mode: bool = True  # FTP only
+    ftp_explicit_ssl: bool = False
     verify_host_keys: str = "ask"  # ask, always, never
 
 

--- a/src/portkeydrop/sites.py
+++ b/src/portkeydrop/sites.py
@@ -204,6 +204,7 @@ class Site:
     username: str = ""
     password: str = ""
     key_path: str = ""
+    ftp_explicit_ssl: bool = False
     initial_dir: str = "/"
     notes: str = ""
 
@@ -215,6 +216,7 @@ class Site:
             username=self.username,
             password=self.password,
             key_path=self.key_path,
+            ftp_explicit_ssl=self.ftp_explicit_ssl if self.protocol == "ftp" else False,
         )
 
 

--- a/tests/_wx_stub.py
+++ b/tests/_wx_stub.py
@@ -88,6 +88,7 @@ def _create_fake_wx() -> tuple[types.ModuleType, types.ModuleType]:
     fake_wx.BoxSizer = lambda *args, **kwargs: _SimpleWidget()
     fake_wx.StaticText = lambda *args, **kwargs: _SimpleWidget()
     fake_wx.Choice = lambda *args, **kwargs: _SimpleWidget()
+    fake_wx.CheckBox = lambda *args, **kwargs: _SimpleWidget()
     fake_wx.TextCtrl = lambda *args, **kwargs: _SimpleWidget()
     fake_wx.ListBox = lambda *args, **kwargs: _SimpleWidget()
     fake_wx.Button = lambda *args, **kwargs: _SimpleWidget()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,7 +84,12 @@ def _hydrate_frame(module):
     frame._retry_last_failed_item = MagicMock()
     frame._toolbar_panel = MagicMock()
     frame._settings = SimpleNamespace(
-        connection=SimpleNamespace(timeout=45, passive_mode=False, verify_host_keys="never"),
+        connection=SimpleNamespace(
+            timeout=45,
+            passive_mode=False,
+            ftp_explicit_ssl=False,
+            verify_host_keys="never",
+        ),
         display=SimpleNamespace(progress_interval=25),
         transfer=SimpleNamespace(overwrite_mode="ask"),
     )
@@ -708,10 +713,13 @@ def test_toolbar_protocol_change_uses_webdav_default_port(app_module):
     frame = _hydrate_frame(app_module)
     frame.tb_protocol = MagicMock(GetStringSelection=MagicMock(return_value="webdav"))
     frame.tb_port = MagicMock()
+    frame.tb_ftp_ssl = MagicMock()
 
     frame._on_toolbar_protocol_change(None)
 
     frame.tb_port.SetValue.assert_called_once_with("443")
+    frame.tb_ftp_ssl.Enable.assert_called_once_with(False)
+    frame.tb_ftp_ssl.SetValue.assert_called_once_with(False)
 
 
 def test_effective_site_port_uses_webdav_default(app_module):

--- a/tests/test_importers_filezilla.py
+++ b/tests/test_importers_filezilla.py
@@ -56,7 +56,9 @@ def test_parse_file_ftps_protocol(tmp_path):
     xml = '<?xml version="1.0"?><FileZilla3><Servers><Server><Host>h.com</Host><Protocol>3</Protocol><Port>21</Port><User>u</User><Pass></Pass><RemoteDir></RemoteDir><Name>X</Name><Comments></Comments></Server></Servers></FileZilla3>'
     f = tmp_path / "sm.xml"
     f.write_text(xml)
-    assert parse_file(f)[0].protocol == "ftps"
+    site = parse_file(f)[0]
+    assert site.protocol == "ftp"
+    assert site.ftp_explicit_ssl is True
 
 
 def test_parse_file_invalid_port(tmp_path):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -19,6 +19,7 @@ import pytest
 from portkeydrop.protocols import (
     ConnectionInfo,
     FTPClient,
+    FTPSAuthSSLClient,
     FTPSClient,
     HostKeyPolicy,
     Protocol,
@@ -138,6 +139,10 @@ class TestConnectionInfo:
         info = ConnectionInfo(protocol=Protocol.FTP)
         assert info.effective_port == 21
 
+    def test_effective_port_explicit_ftp_ssl(self):
+        info = ConnectionInfo(protocol=Protocol.FTP, ftp_explicit_ssl=True)
+        assert info.effective_port == 21
+
     def test_effective_port_default_ftps(self):
         info = ConnectionInfo(protocol=Protocol.FTPS)
         assert info.effective_port == 990
@@ -160,6 +165,15 @@ class TestCreateClient:
         info = ConnectionInfo(protocol=Protocol.FTP, host="example.com")
         client = create_client(info)
         assert isinstance(client, FTPClient)
+
+    def test_create_explicit_ftp_ssl_client(self):
+        info = ConnectionInfo(
+            protocol=Protocol.FTP,
+            host="example.com",
+            ftp_explicit_ssl=True,
+        )
+        client = create_client(info)
+        assert isinstance(client, FTPSAuthSSLClient)
 
     def test_create_ftps_client(self):
         info = ConnectionInfo(protocol=Protocol.FTPS, host="example.com")
@@ -555,6 +569,27 @@ class TestFTPClient:
         with pytest.raises(ConnectionError, match="FTP connection failed"):
             client.connect()
         assert not client.connected
+
+    @patch("portkeydrop.protocols.AuthSSLFTP_TLS")
+    def test_explicit_ssl_connect_uses_auth_ssl_client(self, mock_ftp_class):
+        mock_ftp = MagicMock()
+        mock_ftp.pwd.return_value = "/"
+        mock_ftp_class.return_value = mock_ftp
+
+        info = ConnectionInfo(
+            protocol=Protocol.FTP,
+            host="example.com",
+            username="user",
+            password="pass",
+            ftp_explicit_ssl=True,
+        )
+        client = FTPSAuthSSLClient(info)
+        client.connect()
+
+        assert client.connected
+        mock_ftp.connect.assert_called_once_with("example.com", 21, 30)
+        mock_ftp.login.assert_called_once_with("user", "pass")
+        mock_ftp.prot_p.assert_called_once()
 
     @patch("ftplib.FTP")
     def test_disconnect(self, mock_ftp_class):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from portkeydrop.protocols import (
+    AuthSSLFTP_TLS,
     ConnectionInfo,
     FTPClient,
     FTPSAuthSSLClient,
@@ -590,6 +591,62 @@ class TestFTPClient:
         mock_ftp.connect.assert_called_once_with("example.com", 21, 30)
         mock_ftp.login.assert_called_once_with("user", "pass")
         mock_ftp.prot_p.assert_called_once()
+
+    @patch("portkeydrop.protocols.AuthSSLFTP_TLS")
+    def test_explicit_ssl_connect_failure_raises_connection_error(self, mock_ftp_class):
+        mock_ftp = MagicMock()
+        mock_ftp.connect.side_effect = OSError("refused")
+        mock_ftp_class.return_value = mock_ftp
+
+        info = ConnectionInfo(protocol=Protocol.FTP, host="example.com", ftp_explicit_ssl=True)
+        client = FTPSAuthSSLClient(info)
+
+        with pytest.raises(ConnectionError, match="FTP explicit SSL connection failed"):
+            client.connect()
+        assert not client.connected
+
+    def test_auth_ssl_command_wraps_plain_socket(self):
+        plain_socket = MagicMock()
+        wrapped_socket = MagicMock()
+        wrapped_file = MagicMock()
+        wrapped_socket.makefile.return_value = wrapped_file
+        client = object.__new__(AuthSSLFTP_TLS)
+        client.sock = plain_socket
+        client.context = MagicMock(wrap_socket=MagicMock(return_value=wrapped_socket))
+        client.host = "ftp.example.com"
+        client.encoding = "utf-8"
+        client.voidcmd = MagicMock()
+
+        client.auth()
+
+        client.voidcmd.assert_called_once_with("AUTH SSL")
+        client.context.wrap_socket.assert_called_once_with(
+            plain_socket, server_hostname="ftp.example.com"
+        )
+        assert client.sock is wrapped_socket
+        assert client.file is wrapped_file
+
+    def test_auth_ssl_requires_connected_socket(self):
+        client = object.__new__(AuthSSLFTP_TLS)
+        client.sock = None
+
+        with pytest.raises(ValueError, match="Not connected"):
+            client.auth()
+
+    def test_auth_ssl_skips_existing_ssl_socket(self, monkeypatch):
+        class FakeSSLSocket:
+            pass
+
+        import portkeydrop.protocols as protocols
+
+        monkeypatch.setattr(protocols.ssl, "SSLSocket", FakeSSLSocket)
+        client = object.__new__(AuthSSLFTP_TLS)
+        client.sock = FakeSSLSocket()
+        client.voidcmd = MagicMock()
+
+        client.auth()
+
+        client.voidcmd.assert_not_called()
 
     @patch("ftplib.FTP")
     def test_disconnect(self, mock_ftp_class):

--- a/tests/test_quick_connect_dialog.py
+++ b/tests/test_quick_connect_dialog.py
@@ -79,6 +79,24 @@ class _Button(_Window):
         return None
 
 
+class _CheckBox(_Window):
+    def __init__(self, *_args, **_kwargs):
+        self.value = False
+        self.enabled = True
+
+    def SetName(self, *_args, **_kwargs):
+        return None
+
+    def Enable(self, enabled):
+        self.enabled = enabled
+
+    def SetValue(self, value):
+        self.value = value
+
+    def GetValue(self):
+        return self.value
+
+
 def _load_quick_connect(monkeypatch):
     wx = types.ModuleType("wx")
     wx.Dialog = _Dialog
@@ -88,6 +106,7 @@ def _load_quick_connect(monkeypatch):
     wx.StaticText = _StaticText
     wx.Choice = _Choice
     wx.TextCtrl = _TextCtrl
+    wx.CheckBox = _CheckBox
     wx.DEFAULT_DIALOG_STYLE = 1
     wx.VERTICAL = 2
     wx.EXPAND = 4
@@ -114,3 +133,18 @@ def test_quick_connect_exposes_webdav_and_default_port(monkeypatch):
 
     assert dialog.port_text.GetValue() == "443"
     assert dialog.get_connection_info().protocol is module.Protocol.WEBDAV
+
+
+def test_quick_connect_ftp_auth_ssl_checkbox(monkeypatch):
+    module = _load_quick_connect(monkeypatch)
+    dialog = module.QuickConnectDialog()
+
+    dialog.protocol_choice.SetSelection(1)
+    dialog._on_protocol_change(None)
+    dialog.ftp_ssl_check.SetValue(True)
+
+    info = dialog.get_connection_info()
+
+    assert info.protocol is module.Protocol.FTP
+    assert info.ftp_explicit_ssl is True
+    assert dialog.port_text.GetValue() == "21"

--- a/tests/test_site_manager_dialog.py
+++ b/tests/test_site_manager_dialog.py
@@ -156,6 +156,25 @@ class _Choice(_Window):
         return self._choices[0] if self._choices else ""
 
 
+class _CheckBox(_Window):
+    def __init__(self, *a, **kw):
+        self._value = False
+        self._enabled = True
+        self._name = ""
+
+    def SetName(self, value):
+        self._name = value
+
+    def Enable(self, enabled):
+        self._enabled = enabled
+
+    def SetValue(self, value):
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+
 class _StaticText(_Window):
     pass
 
@@ -220,6 +239,7 @@ def _make_fake_wx():
     wx.Panel = _Window
     wx.TextCtrl = _TextCtrl
     wx.Button = _Button
+    wx.CheckBox = _CheckBox
     wx.Choice = _Choice
     wx.StaticText = _StaticText
     wx.FlexGridSizer = _FlexGridSizer
@@ -252,6 +272,7 @@ def _make_fake_wx():
     wx.ID_CANCEL = 5101
     wx.WXK_ESCAPE = 27
     wx.EVT_BUTTON = object()
+    wx.EVT_CHOICE = object()
     wx.EVT_LISTBOX = object()
     wx.EVT_LISTBOX_DCLICK = object()
     wx.EVT_CHAR_HOOK = object()

--- a/tests/test_site_manager_dialog.py
+++ b/tests/test_site_manager_dialog.py
@@ -546,6 +546,55 @@ class TestRemoveFocusManagement:
         assert dlg.host_text._value == "gamma.example.com"
 
 
+class TestFTPSSLFields:
+    def _make_populate_dialog(self, mod):
+        dlg = object.__new__(mod.SiteManagerDialog)
+        dlg.name_text = _TextCtrl()
+        dlg.protocol_choice = _Choice(choices=["sftp", "ftp", "ftps"])
+        dlg.host_text = _TextCtrl()
+        dlg.port_text = _TextCtrl()
+        dlg.username_text = _TextCtrl()
+        dlg.password_text = _TextCtrl()
+        dlg.ftp_ssl_check = _CheckBox()
+        dlg.key_path_text = _TextCtrl()
+        dlg.initial_dir_text = _TextCtrl()
+        return dlg
+
+    def test_populate_form_sets_ftp_ssl_checkbox(self, dialog_module):
+        from portkeydrop.sites import Site
+
+        mod, _fake_wx = dialog_module
+        dlg = self._make_populate_dialog(mod)
+        site = Site(protocol="ftp", ftp_explicit_ssl=True)
+
+        mod.SiteManagerDialog._populate_form(dlg, site)
+
+        assert dlg.ftp_ssl_check._value is True
+        assert dlg.ftp_ssl_check._enabled is True
+
+    def test_protocol_change_clears_ftp_ssl_for_non_ftp(self, dialog_module):
+        mod, _fake_wx = dialog_module
+        dlg = object.__new__(mod.SiteManagerDialog)
+        dlg.protocol_choice = MagicMock(GetStringSelection=MagicMock(return_value="sftp"))
+        dlg.ftp_ssl_check = _CheckBox()
+        dlg.ftp_ssl_check.SetValue(True)
+
+        mod.SiteManagerDialog._on_protocol_change(dlg, MagicMock())
+
+        assert dlg.ftp_ssl_check._enabled is False
+        assert dlg.ftp_ssl_check._value is False
+
+    def test_protocol_change_enables_ftp_ssl_for_ftp(self, dialog_module):
+        mod, _fake_wx = dialog_module
+        dlg = object.__new__(mod.SiteManagerDialog)
+        dlg.protocol_choice = MagicMock(GetStringSelection=MagicMock(return_value="ftp"))
+        dlg.ftp_ssl_check = _CheckBox()
+
+        mod.SiteManagerDialog._on_protocol_change(dlg, MagicMock())
+
+        assert dlg.ftp_ssl_check._enabled is True
+
+
 class TestPortValidation:
     """Port field validation in _update_site_from_form."""
 

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -88,6 +88,12 @@ class TestSite:
         info = site.to_connection_info()
         assert info.protocol == Protocol.FTP
 
+    def test_to_connection_info_ftp_explicit_ssl(self):
+        site = Site(protocol="ftp", host="ftp.example.com", ftp_explicit_ssl=True)
+        info = site.to_connection_info()
+        assert info.protocol == Protocol.FTP
+        assert info.ftp_explicit_ssl is True
+
     def test_unique_ids(self):
         s1 = Site()
         s2 = Site()


### PR DESCRIPTION
## Summary
- Add a Use SSL (AUTH SSL) option for FTP connections without making it a separate protocol
- Persist the FTP SSL option across Quick Connect, Site Manager, settings defaults, saved sites, and imports
- Route FTP connections with SSL enabled through AUTH SSL and protected data transfers

## Verification
- uv run python -m ruff check .
- uv run python -m pytest
