### PR TITLE
ci(build): sync nightly trigger on dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   schedule:
-    - cron: "30 3 * * *"  # Nightly at 3:30 UTC
+    # Nightly at 02:17 UTC (10:17 PM EDT / 9:17 PM EST).
+    # GitHub Actions schedules are UTC-only and can queue late, so avoid :00/:30.
+    - cron: "17 2 * * *"
   push:
     tags: ['v*.*.*']
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- keep the dev workflow copy aligned with the new 02:17 UTC nightly trigger
- preserve the Eastern-time note and scheduler-queue rationale added on main

## Verification
- actionlint .github/workflows/build.yml
- git --no-pager diff --check origin/dev...HEAD
