### PR TITLE
fix(build): restore current macOS runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
     name: macOS
     needs: prepare
     if: needs.prepare.outputs.should_build == 'true'
-    runs-on: macos-15-intel
+    runs-on: macos-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Changelog CI now enforces curated user-facing entries and uses them for nightly and stable release notes.
-- macOS release builds now target Intel Macs again so downloaded builds open on older Macs.
+- macOS release builds now use the same current macOS runner family as AccessiWeather to avoid Intel-only frozen-app startup crashes.
 - Starting Portkey Drop again on Windows now restores the running window instead of showing a stale lock-file prompt.
 - Windows nightly builds can connect to SFTP servers again instead of failing with a missing `win32timezone` module.
 - Windows packaged builds now include the native audio libraries needed for built-in sound events.

--- a/tests/test_nuitka_build.py
+++ b/tests/test_nuitka_build.py
@@ -119,7 +119,8 @@ def test_production_build_workflow_uses_nuitka() -> None:
     assert "python -m PyInstaller" not in workflow
     assert "pyinstaller" not in workflow.lower()
     assert "scripts/generate_build_meta.py" in workflow
-    assert "runs-on: macos-15-intel" in workflow
+    assert "runs-on: macos-latest" in workflow
+    assert "macos-15-intel" not in workflow
     assert "dist/PortkeyDrop_Setup_*.exe" in workflow
     assert "dist/PortkeyDrop_Portable_*.zip" in workflow
     assert "dist/PortkeyDrop_macOS_*.zip" in workflow


### PR DESCRIPTION
## Summary
- switch macOS release builds back to the current macOS runner family used by AccessiWeather
- pin the Nuitka workflow test against `macos-15-intel` returning
- update the changelog with the macOS startup-crash fix

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests/test_nuitka_build.py`
- `.\.venv\Scripts\python.exe -m pytest tests/test_changelog_tools.py tests/test_nuitka_build.py`
- `.\.venv\Scripts\python.exe -m ruff check tests\test_nuitka_build.py installer\build_nuitka.py`
- `actionlint .github\workflows\build.yml`
- `git diff --check`
