### PR TITLE
fix(build): sync scheduled nightly workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
+  NUITKA_CACHE_DIR: ${{ github.workspace }}/.nuitka-cache
 
 jobs:
   prepare:
@@ -98,47 +99,42 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
+      - name: Restore Nuitka cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .nuitka-cache
+          key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
+          restore-keys: |
+            nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-
+            nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
       - name: Install dependencies
-        run: pip install -e .[dev] pyinstaller pillow
+        run: pip install -e .[dev,build]
+
+      - name: Install Inno Setup
+        run: choco install innosetup -y --no-progress
 
       - name: Build
         run: |
           python scripts/generate_build_meta.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
-          python -m PyInstaller --clean --noconfirm installer/portkeydrop.spec
+          python installer/build_nuitka.py --tag "${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}"
 
       - name: Validate runtime deps for installer/portable
         run: |
-          python scripts/verify_portable_zip.py --runtime-dir dist/PortkeyDrop_dir --pyz-path build/portkeydrop/PYZ-00.pyz --require-runtime-no-data
-
-      - name: Create installer
-        shell: cmd
-        run: |
-          echo [version]> dist\version.txt
-          echo value=${{ needs.prepare.outputs.version }}>> dist\version.txt
-          choco install innosetup -y --no-progress
-          "%ProgramFiles(x86)%\Inno Setup 6\ISCC.exe" installer\portkeydrop.iss
-
-      - name: Create portable ZIP
-        shell: cmd
-        run: |
-          cd dist
-          if exist "PortkeyDrop_dir" (
-            if exist "PortkeyDrop_portable" rmdir /s /q "PortkeyDrop_portable"
-            xcopy "PortkeyDrop_dir" "PortkeyDrop_portable\" /E /I /Y >nul
-            if not exist "PortkeyDrop_portable\\data" mkdir "PortkeyDrop_portable\\data"
-            cd PortkeyDrop_portable
-            7z a -tzip "..\PortkeyDrop_Portable_v${{ needs.prepare.outputs.version }}.zip" *
-            cd ..
-            rmdir /s /q "PortkeyDrop_portable"
-          ) else (
-            7z a -tzip "PortkeyDrop_Portable_v${{ needs.prepare.outputs.version }}.zip" "PortkeyDrop.exe"
-          )
+          python scripts/verify_portable_zip.py --runtime-dir dist/PortkeyDrop_dir --require-runtime-no-data
 
       - name: Validate portable ZIP contents
         run: |
-          python scripts/verify_portable_zip.py --runtime-dir dist/PortkeyDrop_dir --pyz-path build/portkeydrop/PYZ-00.pyz --require-runtime-no-data --portable-zip dist/PortkeyDrop_Portable_v${{ needs.prepare.outputs.version }}.zip
+          python scripts/verify_portable_zip.py --runtime-dir dist/PortkeyDrop_dir --require-runtime-no-data --portable-zip dist/PortkeyDrop_Portable_v${{ needs.prepare.outputs.version }}.zip
 
-      - uses: actions/upload-artifact@v6
+      - name: Save Nuitka cache
+        if: always()
+        uses: actions/cache/save@v5
+        with:
+          path: .nuitka-cache
+          key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
+
+      - uses: actions/upload-artifact@v7
         with:
           name: windows
           path: |
@@ -162,17 +158,34 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
+      - name: Restore Nuitka cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .nuitka-cache
+          key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
+          restore-keys: |
+            nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-
+            nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
       - name: Install dependencies
         run: |
           pip install --only-binary wxPython wxPython
-          pip install -e .[dev] pyinstaller pillow
+          pip install -e .[dev,build]
 
       - name: Build
         timeout-minutes: 30
         run: |
-          python installer/build.py --skip-installer --tag "${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}"
+          python scripts/generate_build_meta.py ${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}
+          python installer/build_nuitka.py --skip-installer --tag "${{ needs.prepare.outputs.is_nightly == 'true' && needs.prepare.outputs.tag || '' }}"
 
-      - uses: actions/upload-artifact@v6
+      - name: Save Nuitka cache
+        if: always()
+        uses: actions/cache/save@v5
+        with:
+          path: .nuitka-cache
+          key: nuitka-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml', 'installer/build_nuitka.py') }}-${{ github.run_id }}
+
+      - uses: actions/upload-artifact@v7
         with:
           name: macos
           path: |


### PR DESCRIPTION
## Summary
- sync the default-branch scheduled build workflow with the current Nuitka build path
- keep macOS nightlies on `macos-latest`, matching the working AccessiWeather pattern
- leave release publishing in the build workflow only; no separate push-releases or WordPress sync path is added

## Changelog
No `CHANGELOG.md` entry is included because this is a default-branch CI/release workflow correction, not a user-visible app change. I also removed the stale release-push work from the branch before merge.

## Why
The failing May 27 PortkeyDrop nightly was produced by the workflow definition on `main`, even though it checked out `dev` for source. That `main` workflow still used the older PyInstaller macOS packaging path, and the published macOS binary contains PyInstaller bootloader strings matching the reported `[PYI-... Module object for struct is NULL]` traceback.

## Verification
- `actionlint .github\workflows\build.yml`
- `Select-String -Path .github\workflows\build.yml -Pattern 'PyInstaller|pyinstaller|installer/build.py|push-releases|push-to-wordpress|WP_|update-wordpress' -CaseSensitive:$false` produced no matches
- `git diff --check`